### PR TITLE
feat(logs-server): add CORS support for browser-origin envelope POSTs

### DIFF
--- a/.changeset/logs-server-cors.md
+++ b/.changeset/logs-server-cors.md
@@ -1,0 +1,19 @@
+---
+'@davstack/logs-server': minor
+---
+
+Add CORS support for browser-origin envelope POSTs. The sink now responds to
+`OPTIONS` preflights and attaches `Access-Control-Allow-*` headers to ingest
+responses, so browser SDKs can post directly to `http://public@127.0.0.1:5181/1`
+without a same-origin proxy (Vite, webpack-dev-server, etc).
+
+New `cors` config field:
+
+- `"*"` (default) — echo `Access-Control-Allow-Origin: *` (no credentials).
+- `string[]` — allowlist; matching `Origin` is echoed back with `Vary: Origin`,
+  non-matching origins get no CORS headers.
+- `false` — emit no CORS headers (legacy behaviour).
+
+Default-permissive is safe: the sink binds `127.0.0.1` only, the response is
+empty (POST) or a fixed `"diag sink ok"` literal (non-POST), and
+`Access-Control-Allow-Credentials` is never set.

--- a/packages/init/src/templates/logs-server.config.ts.template
+++ b/packages/init/src/templates/logs-server.config.ts.template
@@ -9,4 +9,9 @@ export default {
   host: '127.0.0.1',
   dbPath: '.davstack/logs.db',
   pruneDays: 14,
+  // CORS for browser-origin envelope POSTs. Default "*" is safe (sink binds
+  // 127.0.0.1, no credentials, no readable response). Lock down with an
+  // allowlist or disable entirely:
+  // cors: ["http://localhost:3001"],
+  // cors: false,
 } satisfies ServerConfig;

--- a/packages/logs-server/__tests__/bun-only/cors.test.ts
+++ b/packages/logs-server/__tests__/bun-only/cors.test.ts
@@ -1,0 +1,100 @@
+// CORS preflight + response-header contract for browser-origin envelope
+// POSTs. Sentry's `Content-Type: application/x-sentry-envelope` is non-simple,
+// so the browser sends an OPTIONS preflight first — the sink must echo
+// Access-Control-Allow-* or the actual POST is blocked.
+
+import { test, expect, afterEach } from 'bun:test';
+import { openDb } from '../../src/db.ts';
+import { startServer } from '../../src/server.ts';
+import { filterLogs } from '../../src/query.ts';
+import type { ServerConfig } from '../../src/config.ts';
+
+const stops: Array<() => void> = [];
+afterEach(() => {
+  while (stops.length) stops.pop()!();
+});
+
+function boot(cors?: ServerConfig['cors']) {
+  const db = openDb(':memory:');
+  const srv = startServer({ db, port: 0, cors });
+  stops.push(srv.stop);
+  return { db, srv };
+}
+
+function preflight(port: number, origin: string) {
+  return fetch(`http://127.0.0.1:${port}/api/1/envelope/`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: origin,
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'content-type,sentry-trace,baggage',
+    },
+  });
+}
+
+test('default policy: preflight echoes Access-Control-Allow-Origin: *', async () => {
+  const { srv } = boot();
+  const res = await preflight(srv.port, 'http://localhost:3001');
+  expect(res.status).toBe(204);
+  expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  expect(res.headers.get('access-control-allow-methods')).toBe('POST, OPTIONS');
+  const allowHeaders = res.headers.get('access-control-allow-headers') ?? '';
+  expect(allowHeaders).toContain('content-type');
+  expect(allowHeaders).toContain('sentry-trace');
+  expect(allowHeaders).toContain('baggage');
+});
+
+test('allowlist policy: matching Origin is echoed back with Vary: Origin', async () => {
+  const { srv } = boot(['http://localhost:3001']);
+  const res = await preflight(srv.port, 'http://localhost:3001');
+  expect(res.status).toBe(204);
+  expect(res.headers.get('access-control-allow-origin')).toBe('http://localhost:3001');
+  expect(res.headers.get('vary')).toBe('Origin');
+});
+
+test('allowlist policy: non-matching Origin → no CORS headers (browser blocks)', async () => {
+  const { srv } = boot(['http://localhost:3001']);
+  const res = await preflight(srv.port, 'http://evil.example');
+  expect(res.status).toBe(204);
+  expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  expect(res.headers.get('access-control-allow-methods')).toBeNull();
+});
+
+test('cors: false → no CORS headers regardless of origin', async () => {
+  const { srv } = boot(false);
+  const res = await preflight(srv.port, 'http://localhost:3001');
+  expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  expect(res.headers.get('access-control-allow-methods')).toBeNull();
+});
+
+test('default policy: actual POST writes row AND carries Access-Control-Allow-Origin: *', async () => {
+  const { db, srv } = boot();
+  const envelope = [
+    JSON.stringify({ sdk: { name: 'sentry.javascript.browser', version: '9.41.0' } }),
+    JSON.stringify({
+      type: 'log',
+      item_count: 1,
+      content_type: 'application/vnd.sentry.items.log+json',
+    }),
+    JSON.stringify({
+      items: [
+        {
+          timestamp: 1_700_000_000.0,
+          trace_id: 'a'.repeat(32),
+          level: 'info',
+          body: 'cors-post-test',
+          attributes: { 'diag.project': { value: 'cors-test', type: 'string' } },
+        },
+      ],
+    }),
+  ].join('\n');
+  const res = await fetch(`http://127.0.0.1:${srv.port}/api/1/envelope/`, {
+    method: 'POST',
+    headers: { Origin: 'http://localhost:3001', 'content-type': 'application/x-sentry-envelope' },
+    body: envelope,
+  });
+  expect(res.status).toBe(200);
+  expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  const rows = filterLogs(db, { project: 'cors-test' });
+  expect(rows.map((r) => r.msg)).toEqual(['cors-post-test']);
+});

--- a/packages/logs-server/docs/setup.md
+++ b/packages/logs-server/docs/setup.md
@@ -10,6 +10,7 @@ export default {
   host: "127.0.0.1",
   dbPath: ".davstack/logs.db", // relative to repo root
   pruneDays: 14,                // 0 disables background prune
+  // cors: "*",                 // browser CORS policy (see §7); default permissive
 }
 ```
 
@@ -149,7 +150,30 @@ Working reference: `~/dev/traffease_man/react/src/config/sentry.ts`.
 
 The bin shim spawns **`bun`** by default (server uses `bun:sqlite` + `Bun.serve`). Force Node with `LOGS_SERVER_RUNTIME=node` — uses `--experimental-transform-types`, no build step.
 
-## 6. Sanity check
+## 6. CORS (browser DSN posts)
+
+Browser SDKs that post envelopes directly to the sink (via `Sentry.init({ dsn: "http://public@127.0.0.1:5181/1" })`) trigger a CORS preflight — Sentry's `Content-Type: application/x-sentry-envelope` is non-simple. The sink ships with default-permissive CORS so this Just Works; no Vite/webpack proxy needed.
+
+Three modes via the `cors` config field:
+
+```ts
+// .davstack/config/logs-server.config.ts
+export default {
+  cors: "*",                                 // default; echo Allow-Origin: * (no creds)
+  // cors: ["http://localhost:3001"],        // allowlist; echo matching origin + Vary: Origin
+  // cors: false,                            // emit no CORS headers (legacy behaviour)
+}
+```
+
+Default-permissive is safe because:
+
+1. The sink binds to `127.0.0.1` only — unreachable off-host.
+2. The response body is empty on `POST` and a fixed `"diag sink ok"` on non-POST — nothing readable to leak cross-origin.
+3. `Access-Control-Allow-Credentials` is never set, so cookies/auth are not in scope.
+
+Lock down with an allowlist or `false` if you disagree.
+
+## 7. Sanity check
 
 ```bash
 curl -s -X POST http://127.0.0.1:5181/envelope/ \

--- a/packages/logs-server/src/config.ts
+++ b/packages/logs-server/src/config.ts
@@ -17,6 +17,16 @@ export type ServerConfig = {
   host?: string;
   dbPath?: string;
   pruneDays?: number;
+  /**
+   * CORS policy for browser-origin requests. Sink binds to 127.0.0.1
+   * so default-permissive is safe.
+   *
+   *   "*"      — default; echo Access-Control-Allow-Origin: * (no creds)
+   *   string[] — allowlist; if request Origin matches, echo it back + Vary: Origin
+   *              otherwise send no CORS headers (browser will block)
+   *   false    — emit no CORS headers (legacy behaviour)
+   */
+  cors?: '*' | string[] | false;
 };
 
 export type LoadedConfig = ServerConfig & {
@@ -55,6 +65,7 @@ export async function loadConfig(cwd: string = process.cwd()): Promise<LoadedCon
     host: typeof raw.host === 'string' ? raw.host : undefined,
     dbPath: typeof raw.dbPath === 'string' ? raw.dbPath : undefined,
     pruneDays: typeof raw.pruneDays === 'number' ? raw.pruneDays : undefined,
+    cors: normalizeCors(raw.cors),
     _source: configPath,
     _repoRoot: repoRoot,
   };
@@ -66,6 +77,15 @@ export async function loadConfig(cwd: string = process.cwd()): Promise<LoadedCon
   }
 
   return merged;
+}
+
+function normalizeCors(value: unknown): ServerConfig['cors'] {
+  if (value === false) return false;
+  if (value === '*') return '*';
+  if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+    return value as string[];
+  }
+  return undefined;
 }
 
 function pathToFileUrl(p: string): string {

--- a/packages/logs-server/src/index.ts
+++ b/packages/logs-server/src/index.ts
@@ -178,7 +178,12 @@ const cli = defineCli({
           dbPath((ctx.flags.db as string | undefined) ?? configDbPath),
         );
         const db = openDb(file);
-        const srv = startServer({ db, port: effectivePort, host: effectiveHost });
+        const srv = startServer({
+          db,
+          port: effectivePort,
+          host: effectiveHost,
+          cors: config.cors,
+        });
         process.stdout.write(
           `log-server listening on http://${srv.host}:${srv.port}  db=${file}\n`,
         );

--- a/packages/logs-server/src/server.ts
+++ b/packages/logs-server/src/server.ts
@@ -3,22 +3,60 @@
 // JS `tunnel` hits a relative path). It ALWAYS replies 200 and never throws —
 // a sink that 5xx's or hangs would induce SDK retry storms and block the very
 // app it observes (notes 03).
+//
+// CORS: browser SDKs posting envelopes via DSN (Content-Type
+// application/x-sentry-envelope is non-simple) trigger a preflight. Default
+// policy is "*" — safe because the sink binds 127.0.0.1 only and never sets
+// Allow-Credentials, so no readable response is exposed cross-origin. Lock
+// down per-origin or disable via the `cors` config field.
 
 import type { Database } from 'bun:sqlite';
+import type { ServerConfig } from './config.ts';
 import { handleIngest } from './ingest.ts';
 import { decodeBody } from './decode.ts';
+
+export function corsHeadersFor(
+  origin: string | null,
+  policy: ServerConfig['cors'],
+): Headers {
+  const h = new Headers();
+  if (policy === false) return h;
+  if (policy === '*' || policy === undefined) {
+    h.set('Access-Control-Allow-Origin', '*');
+  } else if (Array.isArray(policy) && origin && policy.includes(origin)) {
+    h.set('Access-Control-Allow-Origin', origin);
+    h.set('Vary', 'Origin');
+  } else {
+    return h; // no match → no CORS headers → browser blocks
+  }
+  h.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  h.set(
+    'Access-Control-Allow-Headers',
+    'content-type,content-encoding,sentry-trace,baggage,x-sentry-auth',
+  );
+  h.set('Access-Control-Max-Age', '86400');
+  return h;
+}
 
 export function startServer(opts: {
   db: Database;
   port?: number;
   host?: string;
+  cors?: ServerConfig['cors'];
 }): { port: number; host: string; stop: () => void } {
   const host = opts.host ?? process.env.DIAG_HOST ?? '127.0.0.1';
+  const corsPolicy = opts.cors;
   const server = Bun.serve({
     port: opts.port ?? (Number(process.env.DIAG_PORT) || 7077),
     hostname: host,
     async fetch(req) {
-      if (req.method !== 'POST') return new Response('diag sink ok\n', { status: 200 });
+      const cors = corsHeadersFor(req.headers.get('origin'), corsPolicy);
+      if (req.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: cors });
+      }
+      if (req.method !== 'POST') {
+        return new Response('diag sink ok\n', { status: 200, headers: cors });
+      }
       try {
         // Real SDKs gzip the envelope and set Content-Encoding; reading text()
         // on a gzip body silently produced zero rows. Decode by encoding.
@@ -27,9 +65,11 @@ export function startServer(opts: {
       } catch {
         // swallow — fire-and-forget; the app must never see a failure here
       }
-      return new Response(null, { status: 200 });
+      return new Response(null, { status: 200, headers: cors });
     },
     error() {
+      // No request in scope here — emit no CORS headers; browsers ignore a
+      // failed response anyway, but server-side emitters still see a 200.
       return new Response(null, { status: 200 });
     },
   });


### PR DESCRIPTION
## Summary

Adds first-class CORS handling to `@davstack/logs-server` so browser apps can point their Sentry DSN directly at the sink (`http://public@127.0.0.1:5181/1`) instead of needing Sentry's `tunnel:` option + a same-origin dev-server proxy (Vite / webpack-dev-server / etc).

Before this PR: the sink replied 200 with **zero** `Access-Control-Allow-*` headers, so browser preflight blocked the POST and envelopes never reached the sink. Every browser consumer had to add a same-origin tunnel workaround.

## Design

New optional `cors?: "*" | string[] | false` field on `ServerConfig`:

- **`"*"` (default when omitted)** — echoes `Access-Control-Allow-Origin: *`. Safe because the sink binds to `127.0.0.1` only, exposes no readable GET surface, and never sets `Allow-Credentials: true`.
- **`string[]`** — allowlist; if request `Origin` matches, echo it back with `Vary: Origin`. Otherwise no CORS headers (browser blocks).
- **`false`** — emit no CORS headers (pre-existing behaviour, for anyone who wants the sink unreachable from the browser layer).

Headers attached to both the OPTIONS preflight (204) and the actual ingest response (200):

```
Access-Control-Allow-Origin: <per policy>
Access-Control-Allow-Methods: POST, OPTIONS
Access-Control-Allow-Headers: content-type,content-encoding,sentry-trace,baggage,x-sentry-auth
Access-Control-Max-Age: 86400
```

`Allow-Headers` covers everything Sentry's browser SDK attaches on envelope POSTs.

## What changed

- `packages/logs-server/src/config.ts` — `cors` field on `ServerConfig` + `normalizeCors` loader helper.
- `packages/logs-server/src/server.ts` — exports `corsHeadersFor`; OPTIONS branch returns 204 with CORS headers; non-POST + POST responses attach the same headers; `startServer` accepts `cors` in opts.
- `packages/logs-server/src/index.ts` — passes `config.cors` through to `startServer`.
- `packages/logs-server/__tests__/bun-only/cors.test.ts` — **5 new tests** (default permissive, allowlist match w/ Vary, allowlist non-match, `false`, POST + ingest).
- `packages/logs-server/docs/setup.md` — new §6 CORS section + commented config example.
- `packages/init/src/templates/logs-server.config.ts.template` — commented `cors:` example showing allowlist mode.
- `.changeset/logs-server-cors.md` — minor bump.

## Test results

- `pnpm --filter @davstack/logs-server build` — green (tsup ESM).
- `pnpm --filter @davstack/logs-server test` — **5/5 existing envelope tests pass**.
- `bun test __tests__/bun-only/cors.test.ts` — **5/5 pass, 17 expect() calls**.

CORS tests live in `__tests__/bun-only/` (alongside `acceptance.test.ts`) because they boot a real `Bun.serve` instance; the vitest workspace explicitly excludes `__tests__/bun-only/**`.

## End-to-end verification against a real consumer (`traffease_man`)

Built this branch, `pnpm pack` → installed into a real React app (`@sentry/react@9.47.1`), removed the `tunnel:` config + Vite `/__diag` proxy on the consumer side:

```bash
# preflight
curl -i -X OPTIONS http://127.0.0.1:5181/api/1/envelope/ \
  -H "Origin: http://localhost:3001" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: content-type,sentry-trace,baggage,x-sentry-auth"
# HTTP/1.1 204 No Content
# Access-Control-Allow-Origin: *
# Access-Control-Allow-Methods: POST, OPTIONS
# Access-Control-Allow-Headers: content-type,content-encoding,sentry-trace,baggage,x-sentry-auth
# Access-Control-Max-Age: 86400
```

Real Sentry SDK then posted direct-DSN from the browser; envelopes landed in `diag.sqlite` with correct `diag.project`, `diag.run_id`, `trace_id`, and the new init log message (`destination=local-diag-sink` after dropping the `tunnel:` reference on the consumer side).

## Why default-permissive is safe

1. Sink binds to `127.0.0.1` only — unreachable from any other host.
2. POSTs return empty 200; non-POSTs return the literal string `"diag sink ok"`. No readable user data for a malicious origin to exfiltrate.
3. `Allow-Origin: *` is incompatible with `Allow-Credentials: true`, which is never set. Cookies aren't in scope.
4. Lock-down available via `cors: ["..."]` or `cors: false` for anyone who disagrees.

## Out of scope

- One pre-existing oddity spotted in passing: a few other `__tests__/bun-only/` files use `../src/db.ts` where `../../src/db.ts` is correct. They fail to load under `bun test` on `origin/main` too — unrelated to this change, not touched here.