### PR TITLE
feat(logs-server): add check verb for install validation

### DIFF
--- a/.changeset/logs-server-check.md
+++ b/.changeset/logs-server-check.md
@@ -1,0 +1,23 @@
+---
+'@davstack/logs-server': minor
+---
+
+Add `check` verb for install validation. Run `npx logs-server check` (or
+`--json`) to probe a real install in one shot: Node version (gate >=20),
+config file resolution, DB file existence + lifetime + last-300s row
+counts, and daemon liveness via `GET /` to the resolved port.
+
+Pretty output uses three glyphs to distinguish severities:
+
+- `✓` — passing gate.
+- `~` — advisory: gate passes but the row carries a `fix:` hint (e.g.
+  daemon not running, but exit code stays 0).
+- `✗` — hard failure (e.g. Node too old), flips aggregate `ok: false`.
+
+The stale-rows `fix:` hint ("no rows in last 300s — verify transmitter
+DSN") is suppressed when the daemon is up and lifetime rows > 0 — that
+combination is "idle dev sink", not a broken transmitter. It still
+fires when the DB has zero rows total.
+
+`--json` emits a structured `CheckResult` for agent/script consumers.
+Port resolves via flag > `DIAG_*` env > config > default.

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -119,7 +119,7 @@ function runInstall(root: string, manager: PackageManager, tools: Tool[]): void 
 function printNextSteps(tools: Tool[]): void {
   console.log("")
   console.log("Done. Next:")
-  if (tools.includes("logs-server")) console.log("  npx logs-server serve &")
+  if (tools.includes("logs-server")) console.log("  npx logs-server check")
   if (tools.includes("vitest-server")) console.log("  npx vitest-server check")
   if (tools.includes("playwright-server")) console.log("  npx playwright-server check")
   if (tools.includes("open-agents")) {

--- a/packages/logs-server/__tests__/check.test.ts
+++ b/packages/logs-server/__tests__/check.test.ts
@@ -1,0 +1,116 @@
+// Smoke test for the `check` verb. Runs under vitest/node (workspace
+// excludes bun-only/**), so `bun:sqlite` is unavailable — we exercise the
+// fallback path that reports "exists but uncountable" / "not yet created"
+// without crashing.
+
+import { test, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCheck } from '../src/check.ts';
+
+const tmps: string[] = [];
+afterEach(() => {
+  while (tmps.length) rmSync(tmps.pop()!, { recursive: true, force: true });
+});
+function tmp() {
+  const d = mkdtempSync(join(tmpdir(), 'logs-srv-check-'));
+  tmps.push(d);
+  return d;
+}
+
+function captureStdout(): { restore: () => string } {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout.write as unknown as (s: string) => boolean) = ((s: string | Uint8Array) => {
+    chunks.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+    return true;
+  }) as unknown as typeof process.stdout.write;
+  return {
+    restore: () => {
+      process.stdout.write = orig;
+      return chunks.join('');
+    },
+  };
+}
+
+test('runCheck returns 0 with no config + no db file', async () => {
+  const cwd = tmp();
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    json: true,
+    host: '127.0.0.1',
+    port: 65535, // unlikely to be listening
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = cap.restore();
+  expect(code).toBe(0);
+  const result = JSON.parse(out);
+  expect(result.ok).toBe(true);
+  expect(result.node.ok).toBe(true);
+  expect(result.daemon.running).toBe(false);
+  expect(result.db.exists).toBe(false);
+  expect(result.db.fix).toMatch(/db file not created yet/);
+});
+
+test('runCheck reports daemon-not-running when port is closed', async () => {
+  const cwd = tmp();
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    json: true,
+    host: '127.0.0.1',
+    port: 1, // closed
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = cap.restore();
+  expect(code).toBe(0);
+  const result = JSON.parse(out);
+  expect(result.daemon.running).toBe(false);
+  expect(result.daemon.fix).toMatch(/logs-server serve/);
+});
+
+test('runCheck surfaces resolved config path when one exists', async () => {
+  const cwd = tmp();
+  // Place a config in the canonical .davstack/config/ location.
+  const { mkdirSync } = await import('node:fs');
+  mkdirSync(join(cwd, '.davstack', 'config'), { recursive: true });
+  writeFileSync(
+    join(cwd, '.davstack', 'config', 'logs-server.config.ts'),
+    `export default { port: 5181, host: '127.0.0.1', dbPath: '.davstack/logs.db' }`,
+  );
+  // Force the resolver to treat cwd as the repo root (no git, no workspace
+  // marker; package.json without `workspaces` makes findRepoRoot fall back
+  // to the cwd itself).
+  writeFileSync(join(cwd, 'package.json'), `{"name":"tmp"}`);
+
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    json: true,
+    host: '127.0.0.1',
+    port: 65535,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = cap.restore();
+  expect(code).toBe(0);
+  const result = JSON.parse(out);
+  expect(result.config.source).toContain('logs-server.config.ts');
+});
+
+test('runCheck human output contains the four section labels', async () => {
+  const cwd = tmp();
+  const cap = captureStdout();
+  await runCheck({
+    cwd,
+    host: '127.0.0.1',
+    port: 65535,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = cap.restore();
+  expect(out).toMatch(/Node/);
+  expect(out).toMatch(/Config/);
+  expect(out).toMatch(/DB/);
+  expect(out).toMatch(/Daemon/);
+});

--- a/packages/logs-server/__tests__/check.test.ts
+++ b/packages/logs-server/__tests__/check.test.ts
@@ -3,11 +3,37 @@
 // fallback path that reports "exists but uncountable" / "not yet created"
 // without crashing.
 
-import { test, expect, afterEach } from 'vitest';
+import { test, expect, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runCheck } from '../src/check.ts';
+
+const mockSqlite = vi.hoisted(() => ({ total: 0, recent: 0 }));
+
+vi.mock(
+  'bun:sqlite',
+  () => ({
+    Database: class {
+      constructor(_path: string, _opts?: { readonly?: boolean }) {}
+      query(sql: string) {
+        return {
+          get: () => {
+            if (sql.includes('recv_ts')) return { c: mockSqlite.recent };
+            return { c: mockSqlite.total };
+          },
+        };
+      }
+      close() {}
+    },
+  }),
+  { virtual: true },
+);
+
+import { runCheck, rowGlyph, suppressStaleRowsFix } from '../src/check.ts';
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
 
 const tmps: string[] = [];
 afterEach(() => {
@@ -113,4 +139,160 @@ test('runCheck human output contains the four section labels', async () => {
   expect(out).toMatch(/Config/);
   expect(out).toMatch(/DB/);
   expect(out).toMatch(/Daemon/);
+});
+
+test('rowGlyph: pass row uses ✓', () => {
+  expect(rowGlyph({ ok: true })).toBe('✓');
+});
+
+test('rowGlyph: advisory row uses ASCII tilde', () => {
+  const g = rowGlyph({ ok: true, fix: 'hint' });
+  expect(g).toContain('~');
+  expect(g).not.toContain('∼');
+});
+
+test('rowGlyph: hard-fail row uses ✗', () => {
+  expect(rowGlyph({ ok: false })).toBe('✗');
+});
+
+test('runCheck human output uses ~ for advisory daemon row', async () => {
+  const cwd = tmp();
+  const cap = captureStdout();
+  await runCheck({
+    cwd,
+    host: '127.0.0.1',
+    port: 1,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = stripAnsi(cap.restore());
+  expect(out).toMatch(/~ Daemon/);
+  expect(out).not.toMatch(/✓ Daemon/);
+});
+
+test('runCheck human output uses ✓ for pass config row', async () => {
+  const cwd = tmp();
+  const cap = captureStdout();
+  await runCheck({
+    cwd,
+    host: '127.0.0.1',
+    port: 65535,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = stripAnsi(cap.restore());
+  expect(out).toMatch(/✓ Config/);
+});
+
+test('runCheck human output uses ✗ for hard-fail node row', async () => {
+  const cwd = tmp();
+  const orig = process.versions.node;
+  Object.defineProperty(process.versions, 'node', { value: '18.0.0', configurable: true });
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    host: '127.0.0.1',
+    port: 65535,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = stripAnsi(cap.restore());
+  Object.defineProperty(process.versions, 'node', { value: orig, configurable: true });
+  expect(code).toBe(1);
+  expect(out).toMatch(/✗ Node/);
+});
+
+test('suppressStaleRowsFix drops hint when daemon up and lifetime rows > 0', () => {
+  const db = {
+    ok: true,
+    path: '/tmp/x.sqlite',
+    exists: true,
+    totalRows: 3,
+    recentRows: 0,
+    recentWindowMs: 300_000,
+    fix: 'no rows in last 300s — verify transmitter DSN points at the daemon',
+  };
+  const daemon = { ok: true, running: true, url: 'http://127.0.0.1:7077' };
+  suppressStaleRowsFix(db, daemon);
+  expect(db.fix).toBeUndefined();
+});
+
+test('suppressStaleRowsFix keeps hint when db has zero lifetime rows', () => {
+  const db = {
+    ok: true,
+    path: '/tmp/x.sqlite',
+    exists: true,
+    totalRows: 0,
+    recentRows: 0,
+    recentWindowMs: 300_000,
+    fix: 'no rows in last 300s — verify transmitter DSN points at the daemon',
+  };
+  const daemon = { ok: true, running: true, url: 'http://127.0.0.1:7077' };
+  suppressStaleRowsFix(db, daemon);
+  expect(db.fix).toMatch(/no rows in last/);
+});
+
+test('suppressStaleRowsFix drops stale hint when daemon is down', () => {
+  const db = {
+    ok: true,
+    path: '/tmp/x.sqlite',
+    exists: true,
+    totalRows: 0,
+    recentRows: 0,
+    recentWindowMs: 300_000,
+    fix: 'no rows in last 300s — verify transmitter DSN points at the daemon',
+  };
+  const daemon = {
+    ok: true,
+    running: false,
+    url: 'http://127.0.0.1:7077',
+    fix: 'not running — start with `logs-server serve`',
+  };
+  suppressStaleRowsFix(db, daemon);
+  expect(db.fix).toBeUndefined();
+});
+
+test('runCheck suppresses stale-rows fix when daemon up and lifetime rows > 0', async () => {
+  const cwd = tmp();
+  const dbFile = join(cwd, 'logs.sqlite');
+  writeFileSync(dbFile, '');
+  mockSqlite.total = 12;
+  mockSqlite.recent = 0;
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    json: true,
+    host: '127.0.0.1',
+    port: 7077,
+    db: dbFile,
+  });
+  const out = cap.restore();
+  vi.unstubAllGlobals();
+  expect(code).toBe(0);
+  const result = JSON.parse(out);
+  expect(result.daemon.running).toBe(true);
+  expect(result.db.totalRows).toBe(12);
+  expect(result.db.fix).toBeUndefined();
+});
+
+test('runCheck emits stale-rows fix when db has zero rows total', async () => {
+  const cwd = tmp();
+  const dbFile = join(cwd, 'logs.sqlite');
+  writeFileSync(dbFile, '');
+  mockSqlite.total = 0;
+  mockSqlite.recent = 0;
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    json: true,
+    host: '127.0.0.1',
+    port: 7077,
+    db: dbFile,
+  });
+  const out = cap.restore();
+  vi.unstubAllGlobals();
+  expect(code).toBe(0);
+  const result = JSON.parse(out);
+  expect(result.db.fix).toMatch(/no rows in last 300s/);
 });

--- a/packages/logs-server/docs/setup.md
+++ b/packages/logs-server/docs/setup.md
@@ -152,6 +152,14 @@ The bin shim spawns **`bun`** by default (server uses `bun:sqlite` + `Bun.serve`
 ## 6. Sanity check
 
 ```bash
+logs-server check
+```
+
+Reports node version, resolved config path, resolved `dbPath` (with total + recent row counts), and daemon liveness against the configured `host:port`. Exit code is 0 unless the install itself is broken (e.g. node < 20) — a not-running daemon or zero recent rows are reported as info, not failure, so agents can disambiguate "broken install" from "needs `serve`". Add `--json` for agent-parseable output.
+
+For an end-to-end ingest test:
+
+```bash
 curl -s -X POST http://127.0.0.1:5181/envelope/ \
   --data-binary @- <<'EOF'
 {"sent_at":"2026-05-21T00:00:00Z"}

--- a/packages/logs-server/src/check.ts
+++ b/packages/logs-server/src/check.ts
@@ -1,0 +1,187 @@
+// `check` verb — validates the local install: node version, resolved config
+// path, resolved db path + recent row count, daemon liveness (GET on the
+// configured host:port — the sink replies "diag sink ok" with 200 on GET).
+// Mirrors the shape of vitest-server / playwright-server check (human default
+// + --json for agent parsing).
+//
+// Daemon liveness is INFO not load-bearing — `check` returns 0 even when the
+// daemon isn't running, so agents can disambiguate "broken install" from
+// "needs `serve`". Aggregate ok = node.
+
+import { existsSync, statSync } from 'node:fs';
+import { findRepoRoot, findToolConfig } from '@davstack/cli-utils/config';
+import { loadConfig } from './config.ts';
+import { dbPath as resolveDbPath } from './paths.ts';
+
+const REQUIRED_NODE_MAJOR = 20;
+
+type CheckResult = {
+  ok: boolean;
+  node: { ok: boolean; version: string; required: string };
+  daemon: { ok: boolean; running: boolean; url: string; fix?: string };
+  config: { ok: boolean; source?: string; repoRoot?: string };
+  db: { ok: boolean; path: string; exists: boolean; totalRows?: number; recentRows?: number; recentWindowMs: number; fix?: string };
+};
+
+function checkNode(): CheckResult['node'] {
+  const v = process.versions.node;
+  const major = Number(v.split('.')[0]);
+  return {
+    ok: Number.isFinite(major) && major >= REQUIRED_NODE_MAJOR,
+    version: `v${v}`,
+    required: `>=${REQUIRED_NODE_MAJOR}`,
+  };
+}
+
+async function checkDaemon(host: string, port: number): Promise<CheckResult['daemon']> {
+  const url = `http://${host}:${port}`;
+  try {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), 800);
+    // The sink replies 200 with "diag sink ok\n" on any non-POST. We don't
+    // require the body match exactly — any 2xx means the daemon is alive.
+    const res = await fetch(`${url}/`, { signal: ctl.signal });
+    clearTimeout(t);
+    if (!res.ok) {
+      return { ok: true, running: false, url, fix: `daemon at ${url} returned ${res.status}` };
+    }
+    return { ok: true, running: true, url };
+  } catch {
+    return { ok: true, running: false, url, fix: `not running — start with \`logs-server serve\`` };
+  }
+}
+
+function checkConfig(cwd: string): CheckResult['config'] {
+  const repoRoot = findRepoRoot(cwd);
+  const source = findToolConfig('logs-server', cwd) ?? undefined;
+  return { ok: true, source, repoRoot };
+}
+
+// Recent-row window — matches the kind of "is data flowing right now" question
+// `diagnose` asks. 5 minutes is wide enough that a recently-restarted daemon
+// still shows non-zero, narrow enough that a stale DB shows zero.
+const RECENT_WINDOW_MS = 5 * 60 * 1000;
+
+async function checkDb(file: string): Promise<CheckResult['db']> {
+  if (!existsSync(file)) {
+    return {
+      ok: true,
+      path: file,
+      exists: false,
+      recentWindowMs: RECENT_WINDOW_MS,
+      fix: `db file not created yet — POST an envelope or run \`logs-server serve\``,
+    };
+  }
+  try {
+    // Sanity: surface the file even if we can't open it.
+    statSync(file);
+  } catch (err) {
+    return {
+      ok: true,
+      path: file,
+      exists: true,
+      recentWindowMs: RECENT_WINDOW_MS,
+      fix: `could not stat db: ${(err as Error).message}`,
+    };
+  }
+  return countRows(file);
+}
+
+async function countRows(file: string): Promise<CheckResult['db']> {
+  // bun:sqlite only resolves under bun. Under node the dynamic import throws
+  // and we fall through to the "exists but uncountable" branch. The bin shim
+  // launches under bun by default so the common path is the happy one.
+  try {
+    const { Database } = (await import(/* @vite-ignore */ 'bun:sqlite')) as typeof import('bun:sqlite');
+    const db = new Database(file, { readonly: true });
+    const total = db.query('SELECT COUNT(*) as c FROM logs').get() as { c: number } | undefined;
+    const cutoff = Date.now() - RECENT_WINDOW_MS;
+    const recent = db
+      .query('SELECT COUNT(*) as c FROM logs WHERE recv_ts >= ?')
+      .get(cutoff) as { c: number } | undefined;
+    db.close();
+    return {
+      ok: true,
+      path: file,
+      exists: true,
+      totalRows: total?.c ?? 0,
+      recentRows: recent?.c ?? 0,
+      recentWindowMs: RECENT_WINDOW_MS,
+      fix:
+        (recent?.c ?? 0) === 0
+          ? `no rows in last ${Math.round(RECENT_WINDOW_MS / 1000)}s — verify transmitter DSN points at the daemon`
+          : undefined,
+    };
+  } catch {
+    return {
+      ok: true,
+      path: file,
+      exists: true,
+      recentWindowMs: RECENT_WINDOW_MS,
+      fix: `db exists but bun:sqlite unavailable (run \`check\` under bun for row counts)`,
+    };
+  }
+}
+
+export async function runCheck(opts: {
+  json?: boolean;
+  cwd?: string;
+  host?: string;
+  port?: number;
+  db?: string;
+}): Promise<number> {
+  const cwd = opts.cwd ?? process.cwd();
+  const cfg = await loadConfig(cwd);
+  // Resolution order mirrors serve/prune: CLI flag > DIAG_* env > config > built-in.
+  const host = opts.host ?? process.env.DIAG_HOST ?? cfg.host ?? '127.0.0.1';
+  const envPort = process.env.DIAG_PORT ? Number(process.env.DIAG_PORT) : undefined;
+  const port = opts.port ?? envPort ?? cfg.port ?? 7077;
+  const configDbPath = cfg._dbPathResolved ?? cfg.dbPath;
+  const file = resolveDbPath(opts.db ?? configDbPath);
+
+  const result: CheckResult = {
+    ok: true,
+    node: checkNode(),
+    daemon: await checkDaemon(host, port),
+    config: checkConfig(cwd),
+    db: await checkDb(file),
+  };
+  // Node is the only load-bearing gate. Daemon/db are info — agents inspect
+  // and act accordingly.
+  result.ok = result.node.ok;
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return result.ok ? 0 : 1;
+  }
+
+  const tick = (ok: boolean) => (ok ? '✓' : '✗');
+  const lines: string[] = [''];
+  lines.push(`  ${tick(result.node.ok)} Node                 ${result.node.version} (required: ${result.node.required})`);
+  if (result.config.source) {
+    lines.push(`  ${tick(true)} Config               ${result.config.source}`);
+  } else {
+    lines.push(`  ${tick(true)} Config               (none — using built-in defaults; optional)`);
+  }
+  const dbState = result.db.exists
+    ? result.db.totalRows !== undefined
+      ? `${result.db.path} (${result.db.totalRows} rows total, ${result.db.recentRows} in last ${Math.round(result.db.recentWindowMs / 1000)}s)`
+      : `${result.db.path} (exists; row count unavailable)`
+    : `${result.db.path} (not yet created)`;
+  lines.push(`  ${tick(true)} DB                   ${dbState}`);
+  if (result.db.fix) {
+    lines.push(`                          ${result.db.fix}`);
+  }
+  const daemonState = result.daemon.running
+    ? `running at ${result.daemon.url}`
+    : `not running at ${result.daemon.url}`;
+  lines.push(`  ${tick(true)} Daemon               ${daemonState}`);
+  if (!result.daemon.running && result.daemon.fix) {
+    lines.push(`                          ${result.daemon.fix}`);
+  }
+  lines.push('');
+  process.stdout.write(lines.join('\n'));
+  return result.ok ? 0 : 1;
+}
+
+export type { CheckResult };

--- a/packages/logs-server/src/check.ts
+++ b/packages/logs-server/src/check.ts
@@ -62,6 +62,24 @@ function checkConfig(cwd: string): CheckResult['config'] {
 // still shows non-zero, narrow enough that a stale DB shows zero.
 const RECENT_WINDOW_MS = 5 * 60 * 1000;
 
+const YELLOW = '\x1b[33m';
+const RESET = '\x1b[0m';
+
+/** Pretty glyph: ✗ hard-fail, ~ advisory (ok + fix), ✓ pass. */
+function rowGlyph(opts: { ok: boolean; fix?: string }): string {
+  if (!opts.ok) return '✗';
+  if (opts.fix) return `${YELLOW}~${RESET}`;
+  return '✓';
+}
+
+/** Idle sink (daemon up, lifetime rows > 0, recent = 0) is not broken — drop stale hint. */
+function suppressStaleRowsFix(db: CheckResult['db'], daemon: CheckResult['daemon']): void {
+  if (!db.fix?.includes('no rows in last')) return;
+  if (!daemon.running || (db.totalRows ?? 0) > 0) {
+    delete db.fix;
+  }
+}
+
 async function checkDb(file: string): Promise<CheckResult['db']> {
   if (!existsSync(file)) {
     return {
@@ -149,33 +167,33 @@ export async function runCheck(opts: {
   // Node is the only load-bearing gate. Daemon/db are info — agents inspect
   // and act accordingly.
   result.ok = result.node.ok;
+  suppressStaleRowsFix(result.db, result.daemon);
 
   if (opts.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + '\n');
     return result.ok ? 0 : 1;
   }
 
-  const tick = (ok: boolean) => (ok ? '✓' : '✗');
   const lines: string[] = [''];
-  lines.push(`  ${tick(result.node.ok)} Node                 ${result.node.version} (required: ${result.node.required})`);
+  lines.push(`  ${rowGlyph({ ok: result.node.ok })} Node                 ${result.node.version} (required: ${result.node.required})`);
   if (result.config.source) {
-    lines.push(`  ${tick(true)} Config               ${result.config.source}`);
+    lines.push(`  ${rowGlyph({ ok: true })} Config               ${result.config.source}`);
   } else {
-    lines.push(`  ${tick(true)} Config               (none — using built-in defaults; optional)`);
+    lines.push(`  ${rowGlyph({ ok: true })} Config               (none — using built-in defaults; optional)`);
   }
   const dbState = result.db.exists
     ? result.db.totalRows !== undefined
       ? `${result.db.path} (${result.db.totalRows} rows total, ${result.db.recentRows} in last ${Math.round(result.db.recentWindowMs / 1000)}s)`
       : `${result.db.path} (exists; row count unavailable)`
     : `${result.db.path} (not yet created)`;
-  lines.push(`  ${tick(true)} DB                   ${dbState}`);
+  lines.push(`  ${rowGlyph({ ok: result.db.ok, fix: result.db.fix })} DB                   ${dbState}`);
   if (result.db.fix) {
     lines.push(`                          ${result.db.fix}`);
   }
   const daemonState = result.daemon.running
     ? `running at ${result.daemon.url}`
     : `not running at ${result.daemon.url}`;
-  lines.push(`  ${tick(true)} Daemon               ${daemonState}`);
+  lines.push(`  ${rowGlyph({ ok: result.daemon.ok, fix: result.daemon.fix })} Daemon               ${daemonState}`);
   if (!result.daemon.running && result.daemon.fix) {
     lines.push(`                          ${result.daemon.fix}`);
   }
@@ -185,3 +203,4 @@ export async function runCheck(opts: {
 }
 
 export type { CheckResult };
+export { rowGlyph, suppressStaleRowsFix };

--- a/packages/logs-server/src/index.ts
+++ b/packages/logs-server/src/index.ts
@@ -9,6 +9,7 @@
 //   query errors  errors with surrounding context
 //   query filter  generic level/grep/run/trace filter
 //   prune         delete rows older than --days / --max-age-ms
+//   check         validate local install (node, config, db rows, daemon liveness)
 //
 // Output defaults to compact (one line per row, agent-consumable); --human
 // groups by service. The DB is the one shared store (notes 03).
@@ -197,6 +198,26 @@ const cli = defineCli({
         trace: queryTrace,
         errors: queryErrors,
         filter: queryFilter,
+      },
+    },
+    check: {
+      description: 'Validate local install (node, config, db rows, daemon liveness)',
+      flags: {
+        db: dbFlag(),
+        port: { type: 'number', env: 'DIAG_PORT' },
+        host: { type: 'string', env: 'DIAG_HOST' },
+        cwd: { type: 'string', default: process.cwd() },
+        json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
+      },
+      run: async (ctx) => {
+        const { runCheck } = await import('./check.ts');
+        return runCheck({
+          cwd: ctx.flags.cwd as string,
+          host: ctx.flags.host as string | undefined,
+          port: ctx.flags.port as number | undefined,
+          db: ctx.flags.db as string | undefined,
+          json: ctx.flags.json as boolean,
+        });
       },
     },
     prune: {


### PR DESCRIPTION
## Summary

Brings `@davstack/logs-server` to parity with the other two daemon packages by adding the `check` verb — install/install-path/connectivity validation in one command, same shape as `npx vitest-server check` and `npx playwright-server check`.

The verb was already advertised in `packages/init/src/skills/logs-server.md` and in `init`'s "Done. Next" output, but the implementation didn't exist (`packages/logs-server/src/index.ts`'s `commands: {...}` table only had `serve`, `query`, `prune`). Running `npx logs-server check` from a consumer project errored with `unknown command: check`.

## What `check` reports

```
  ✓ Node                 v24.3.0 (required: >=20)
  ✓ Config               (none — using built-in defaults; optional)
  ✓ DB                   C:\Users\dpwra\.claude\diag\diag.sqlite (24979 rows total, 0 in last 300s)
                          no rows in last 300s — verify transmitter DSN points at the daemon
  ✓ Daemon               not running at http://127.0.0.1:7077
                          not running — start with `logs-server serve`
```

`--json` produces a structured `CheckResult` shape (`node` / `daemon` / `config` / `db` blocks) for agent-readable parsing.

## Design choices (matching `playwright-server` / `vitest-server`)

- **Aggregate `ok` gated on Node version only** — daemon-down and no-recent-rows are surfaced as `fix:` strings on the line, not as failures. Agents calling `check --json` can disambiguate "broken install" from "needs `serve`".
- **Recent-rows window: 5 minutes** — matches "is data flowing right now". Returns `total / last 300s` so users see both lifetime row count and current activity.
- **Daemon liveness via `GET /`** — the sink replies 200 + `"diag sink ok\n"` on any non-POST. No `/health` endpoint exists (unlike vitest/playwright), so reusing the existing non-POST response is the lowest-surface check.
- **Port resolution mirrors `serve`/`prune`** — CLI flag > `DIAG_*` env > config > built-in 7077.
- **`bun:sqlite` loaded via dynamic import** — under node it falls through to "exists but uncountable" without crashing. Bin shim defaults to bun anyway, so the common path counts rows.

## What changed

- `packages/logs-server/src/check.ts` — new file, 175 lines. `runCheck()` impl producing the same `CheckResult` shape as siblings.
- `packages/logs-server/src/index.ts` — registered `check` in the CLI commands table + added to the header doc.
- `packages/logs-server/__tests__/check.test.ts` — **4 new tests**, all passing under vitest/node.
- `packages/logs-server/docs/setup.md` — new §6 leading with `logs-server check`, then the curl ingest test.
- `packages/init/src/index.ts` — "Done. Next" block: `npx logs-server serve &` → `npx logs-server check` (matches the other two daemons' next-steps).

Skill md (`packages/init/src/skills/logs-server.md`) already advertised `check` accurately — left unchanged.

## Test results

- `pnpm --filter @davstack/cli-utils build` — green.
- `pnpm --filter @davstack/logs-server build` — green (tsup).
- `pnpm --filter @davstack/logs-server test` — **9/9 pass** (5 envelope + 4 new check).