### PR TITLE
chore: add changeset for reenable-dts fix (visibility PR)

### DIFF
--- a/.changeset/reenable-dts.md
+++ b/.changeset/reenable-dts.md
@@ -1,0 +1,15 @@
+---
+"@davstack/cli-utils": patch
+"@davstack/logs-server": patch
+"@davstack/vitest-server": patch
+"@davstack/playwright-server": patch
+---
+
+Ship `.d.ts` declarations so consumers can import `ServerConfig` (and
+other public types) from `@davstack/{logs,vitest,playwright}-server/config`
+and `@davstack/cli-utils` without `TS2307: Cannot find module ... or its
+corresponding type declarations`.
+
+Runtime output is byte-stable — only declarations are new. Non-breaking.
+
+See: 8065fc9 (`fix(daemons): ship .d.ts for @davstack/{cli-utils,logs-server,vitest-server,playwright-server}`)


### PR DESCRIPTION
This PR adds a changeset for commit [`8065fc9`](https://github.com/DawidWraga/davstack/commit/8065fc9852e855dae4f37b0eb2c466f52f9568b7), which **already landed directly on `main`** outside the normal PR flow (see "How this got to main" below). Opening this as a visibility / review surface so the fix can be discussed and the cross-worktree impact assessed before publishing to npm.

**Do not merge until the impact on the three other open branches is decided** — see Cross-worktree impact section.

---

## What `8065fc9` does

Fixes TS2307 (`Cannot find module '@davstack/<pkg>/config' or its corresponding type declarations`) under `tsc --noEmit` for consumers of all four daemon packages.

### Two compounding gaps in the published `1.2.x` daemons

1. **`dts: false` in every daemon's `tsup.config.ts`** — disabled during the tsup migration in #34 because cli-utils had pre-existing type errors that cascaded into the daemons' declaration build. No `.d.ts` shipped.
2. **Exports maps lacked a `types` condition** — even if `.d.ts` existed, modern moduleResolution modes (`bundler` / `node16` / `nodenext`) wouldn't find them without `types` ordered first.

### Root cause

None of the four packages had a `tsconfig.json`, so tsup's dts plugin fell back to non-strict defaults:

- Discriminated unions didn't narrow — `if (!c.ok)` failed to refine `c.error` (TS2339).
- `process` was undefined — no `@types/node` (TS2580).
- `.ts`-suffixed relative imports rejected by tsc declaration emit (TS5097).

Fix the config gaps, the errors evaporate. No public-type loosening required.

### Changes in `8065fc9`

- Added `tsconfig.json` (`strict`, `types: ["node"]`, `moduleResolution: Bundler`, `declaration: true`) to `cli-utils` + each daemon.
- Added `@types/node` devDep to the same four packages.
- Flipped `dts: false` → `dts: true` in the four `tsup.config.ts` files.
- Rewrote `./foo.ts` static + dynamic imports → `./foo.js` across `cli-utils`, `logs-server`, `vitest-server`, `playwright-server`, `open-agents`, `init` (and matching test files). Bundler resolution requires the emitted-form extension for ESM declaration build.
- Converted each `exports` map to object form with `types` first, `default` second.

No `@ts-expect-error`, no `as any`. Runtime JS output is byte-stable; only declarations are new. **Non-breaking** at runtime.

### Verification (done before commit)

- `pnpm --filter @davstack/<pkg> build` clean on all four; `.d.ts` files emit (`config.d.ts` carries `ServerConfig` / `LoadedConfig` / `loadConfig`).
- `pnpm -w exec vitest run` — **209/209 workspace tests pass**.
- Scratch smoke install: `pnpm pack` each daemon → `npm install` into clean dir → `tsc --noEmit` clean under all three of `moduleResolution: bundler`, `node16`, `nodenext`.
- Live consumer test: installed local tarballs into a real downstream project, ran the project's own `tsc --noEmit` → exit 0, all three `import type { ServerConfig } from "@davstack/*/config"` resolved.

### What this changeset does

Patch-bumps all four packages so the Release workflow will publish the fix to npm on merge:

- `@davstack/cli-utils`: 1.1.0 → 1.1.1
- `@davstack/logs-server`: 1.2.0 → 1.2.1
- `@davstack/vitest-server`: 1.2.0 → 1.2.1
- `@davstack/playwright-server`: 1.2.0 → 1.2.1

---

## Cross-worktree impact (three open PRs based off the pre-fix main)

The `.ts → .js` import sweep was repo-wide and touched files that other open branches also touch. Each open PR will need to absorb the rewrite when rebased onto current main.

### Direct file overlap (rebase will surface conflicts in these)

| Open PR | Branch | Files also modified by `8065fc9` |
|---|---|---|
| #38 logs-server CORS | `feat/logs-server-cors` | `packages/logs-server/src/index.ts`, `packages/logs-server/src/server.ts` |
| #39 logs-server `check` verb | `feat/logs-server-check-verb` | `packages/init/src/index.ts`, `packages/logs-server/src/index.ts` |
| #37 TUI | `feat/start-tui` | `pnpm-lock.yaml` only (lockfile churn — auto-resolvable with `pnpm install`) |

### Indirect impact (no file overlap, but the new dts build will break if .ts imports are reintroduced)

All three open branches still use `./foo.ts`-style relative imports in their unmodified files. That is fine for runtime (tsup/tsx tolerates the extension), but if any new file added on a branch uses `.ts` imports AND that file is reachable from a daemon's entrypoint, `dts: true` will reject it on rebuild.

Concretely, each of `feat/logs-server-cors`, `feat/logs-server-check-verb`, and `feat/start-tui` adds new files (`cors.test.ts`, `check.test.ts` / `check.ts`, the entire `packages/tui/src/**`). Authors of those branches should run `pnpm --filter <pkg> build` after rebasing and rewrite any surfaced `.ts` extensions to `.js` if dts errors appear.

### Suggested rebase order

1. Land this changeset PR (or decide not to publish yet — see decision below).
2. Rebase #37 (TUI) — only conflict is pnpm-lock; `pnpm install` resolves it.
3. Rebase #38 (CORS) and #39 (check verb) — review the two-three overlapping `logs-server/src/index.ts` files; the changes are localized (route additions, CLI command additions) and shouldn't conflict semantically with the `.ts→.js` import sweep at the top of the file.
4. After all three rebase clean, decide whether to publish another patch via the standard Version Packages flow.

---

## How this got to main

The fix commit (`8065fc9`) was created and intended to land via PR, but **the push that should have gone only to `fix/reenable-dts` also updated `refs/heads/main`** — a real `PushEvent` to main appears in the GitHub events API, authenticated as the repo owner, 47 seconds after the commit was created.

Eliminated as causes:

- No pre-push hook (local, global, system, or worktree level).
- No `push.default = matching` or `remote.origin.push` refspec anywhere.
- No git alias wrapping `push`; no git wrapper in `PATH`.
- No workflow that pushes to main on `PushEvent` — only `release.yml` runs on push to main, and changesets/action doesn't push back.
- No branch protection rules on main (could not have *prevented* it either, but doesn't *cause* it).

Most plausible remaining cause: an IDE or background tool (VS Code/Cursor git integration, GitHub Desktop, GitLens, or similar) silently amplified the push to include main. Worth checking VS Code settings (`git.postCommitCommand`, `git.followTagsWhenSync`, "publish branch" rules) and any running tray apps. Not blocking this PR; flagged for follow-up.

The Release workflow ran when main was pushed but **did not publish to npm** — no unreleased changeset existed at the time. `@davstack/*` are still at `1.1.0` / `1.2.0` on the registry with the broken (no-`.d.ts`) tarballs. Until this changeset PR + the subsequent Version Packages PR both merge, consumers still pull the broken versions.

---

## Decision points

- [ ] Merge this PR to publish the fix (will trigger a Version Packages PR via changesets/action, which when merged publishes to npm).
- [ ] Or close this PR and defer publishing until #37 / #38 / #39 land and a combined release goes out.
- [ ] Either way: investigate the rogue main push before the next branch goes through this flow.