### PR TITLE
docs(logs-server): sqlite-first read path + schema + recipes

### DIFF
--- a/packages/logs-server/CHANGELOG.md
+++ b/packages/logs-server/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @davstack/logs-server
 
+## 1.3.2
+
+### Patch Changes
+
+- docs: document sqlite as primary read path, ship recipes, soft-deprecate `query` verb
+  ([#49](https://github.com/DawidWraga/davstack/issues/49))
+
+  `docs/reading-logs.md` rewritten around sqlite. Corrects the prior
+  `ts` / `recv_ts TEXT` schema (they are `REAL`), documents the OTel
+  `{value, type}` envelope that puts probe payloads at
+  `data.attributes.<key>.value`, and ships three recipes that the CLI
+  verbs can't cover: probe-tag timeline with structured attributes,
+  seam histogram (runaway-loop sanity check), and last-N (`--limit`
+  returns ascending, sqlite can `ORDER BY DESC`).
+
+  CLI: parent `query` description now points at `reading-logs.md` and
+  describes the verbs as "pre-baked cuts for sanity / one-off greps."
+  Verbs unchanged.
+
+  No code changes to the daemon, ingest path, or DB schema.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/logs-server/README.md
+++ b/packages/logs-server/README.md
@@ -37,4 +37,4 @@ $ logs-server query filter --grep "clicked save"
 
 - [docs/setup.md](./docs/setup.md) — config file, env vars, runtime selection
 - [docs/writing-logs.md](./docs/writing-logs.md) — transmitter setup per SDK
-- [docs/reading-logs.md](./docs/reading-logs.md) — every query verb + raw sqlite recipes
+- [docs/reading-logs.md](./docs/reading-logs.md) — sqlite schema, recipes, and CLI verb reference (sqlite is the recommended read path for any non-trivial diagnosis)

--- a/packages/logs-server/docs/reading-logs.md
+++ b/packages/logs-server/docs/reading-logs.md
@@ -1,79 +1,93 @@
 # Reading logs
 
-Three layers, increasing power:
-
-1. **CLI query verbs** — pre-baked cuts. 80% of cases.
-2. **`--json` on any verb** — pipe into `jq` / scripts.
-3. **Raw sqlite** on `.davstack/logs.db` — for cuts the CLI doesn't pre-bake.
-
-## CLI verbs
-
-```bash
-logs-server query run    --run r-99                  # timeline for one run_id
-logs-server query trace  --trace 7f3a…               # cross-service assembly for one trace_id
-logs-server query errors --context 20                # errors + N surrounding rows (scoped to --run/--trace too)
-logs-server query filter --level error --grep "timeout" --limit 100
-```
-
-Default output is **compact one-row-per-line** (terminal/agent-friendly):
-
-```
-2026-05-21T13:51:32  error  react  r-99  t-7f3a  request failed  {"status":500}
-```
-
-Flags on every verb: `--json` (full row shape) · `--human` (grouped by service, indented).
-
-## Raw sqlite
-
 ```bash
 sqlite3 .davstack/logs.db
 ```
 
-### Schema
+Structured probe attributes live inside `data` (a JSON blob), so any non-trivial cut needs `json_extract`. The CLI `query` verbs are pre-baked cuts for sanity checks; reach past them as soon as you want structured payloads, compound predicates, or aggregation.
+
+## Schema
 
 ```
 logs(
   id              INTEGER PRIMARY KEY,
-  ts              TEXT,        -- ISO 8601, from transmitter
-  recv_ts         TEXT,        -- ISO 8601, when daemon received
-  project         TEXT,
-  service         TEXT,
-  run_id          TEXT,
+  ts              REAL,     -- Sentry log timestamp, seconds since epoch (float)
+  recv_ts         REAL,     -- server receive time, ms epoch (prune key)
+  project         TEXT,     -- promoted from data.attributes['diag.project'].value
+  service         TEXT,     -- envelope sdk.name
+  run_id          TEXT,     -- promoted from data.attributes['diag.run_id'].value
   trace_id        TEXT,
   span_id         TEXT,
   level           TEXT,
   severity_number INTEGER,
-  logger          TEXT,
-  msg             TEXT,        -- ANSI prefix stripped
-  data            TEXT,        -- JSON blob; everything not promoted
-  tag             TEXT
+  logger          TEXT,     -- promoted from data.attributes['sentry.origin'].value
+  msg             TEXT,     -- Sentry log body, ANSI prefix stripped
+  data            TEXT,     -- raw Sentry log record JSON, verbatim
+  tag             TEXT      -- promoted from data.attributes['diag.tag'].value (nullable)
 )
 ```
 
-Indexed on `(project, run_id, trace_id, level, ts)`. Other predicates full-scan.
+Indexed on `(project, run_id, trace_id, level, ts)`.
 
-### Recipes
+## `data` shape
 
-```sql
--- top error messages this hour
-SELECT msg, count(*) AS n
-FROM logs
-WHERE level='error' AND ts > datetime('now','-1 hour')
-GROUP BY msg ORDER BY n DESC LIMIT 20;
+`data` is the Sentry log record kept verbatim. Structured attributes are wrapped per-key by the OTel transmitter as `{value, type}`:
+
+```ts
+logger.info("checkpoint", { seam: "after-fetch", row_count: 42 })
 ```
 
+stored as:
+
+```json
+{ "body": "checkpoint",
+  "attributes": {
+    "seam":      { "value": "after-fetch", "type": "string" },
+    "row_count": { "value": 42,             "type": "integer" }
+  } }
+```
+
+So probe payloads sit at `data.attributes.<key>.value`. The `{value, type}` wrapper is OTel-standard ergonomic tax — issue [#52](https://github.com/DawidWraga/davstack/issues/52) tracks flattening it.
+
+## Recipes
+
+### Probe-tag timeline with structured attributes
+
+The killer recipe — pick exactly the projection you need from `data.attributes`:
+
 ```sql
--- pull a field out of the data blob
-SELECT ts, msg, json_extract(data, '$.user_id') AS user_id
-FROM logs WHERE json_extract(data, '$.user_id') = 42
+SELECT ts,
+       json_extract(data, '$.body')                       AS msg,
+       json_extract(data, '$.attributes.seam.value')      AS seam,
+       json_extract(data, '$.attributes.row_count.value') AS row_count
+FROM logs
+WHERE ts > :baseline
+  AND json_extract(data, '$.body') LIKE '%<probe-tag>%'
 ORDER BY ts;
 ```
 
+Capture `:baseline` with `SELECT MAX(ts) FROM logs` before kicking off the repro, then query relative to it. ([#51](https://github.com/DawidWraga/davstack/issues/51) tracks first-class iteration scoping.)
+
+### Seam histogram (runaway-loop sanity check)
+
 ```sql
--- distribution of services under one run
-SELECT service, count(*) AS n
-FROM logs WHERE run_id='r-99'
-GROUP BY service ORDER BY n DESC;
+SELECT count(*) AS n,
+       json_extract(data, '$.attributes.seam.value') AS seam
+FROM logs
+WHERE ts > :baseline
+  AND json_extract(data, '$.body') LIKE '%<probe-tag>%'
+GROUP BY seam
+ORDER BY n DESC;
+```
+
+### Last N (`--limit` returns ascending; sqlite to the rescue)
+
+```sql
+SELECT ts, level, msg
+FROM logs
+WHERE level = 'error'
+ORDER BY ts DESC
+LIMIT 20;
 ```
 
 ## Pruning

--- a/packages/logs-server/package.json
+++ b/packages/logs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davstack/logs-server",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "type": "module",
   "description": "Local Sentry-shaped log sink: ingest envelopes over HTTP, persist to per-repo SQLite, query by trace_id/run_id/level.",

--- a/packages/logs-server/src/index.ts
+++ b/packages/logs-server/src/index.ts
@@ -207,7 +207,8 @@ const cli = defineCli({
       },
     },
     query: {
-      description: 'Query the log store',
+      description:
+        'Pre-baked cuts of the log store (sanity / one-off greps). For anything non-trivial — structured probe attributes, compound predicates, aggregation — query .davstack/logs.db directly with sqlite. See packages/logs-server/docs/reading-logs.md.',
       commands: {
         run: queryRun,
         trace: queryTrace,


### PR DESCRIPTION
## Summary

- `docs/reading-logs.md` rewritten around sqlite as the primary read path. The CLI `query` verbs only see promoted columns and can't reach structured probe attributes at `data.attributes.<k>.value`.
- Corrects schema documentation: `ts` / `recv_ts` are `REAL` (Sentry log seconds-epoch float / ms-epoch), not `TEXT` as the prior doc claimed.
- Documents the OTel `{value, type}` envelope inline with a concrete probe-input → stored-shape example.
- Ships three recipes that the CLI verbs can't cover: probe-tag timeline with structured attributes, seam histogram (runaway-loop sanity check), last-N (the `--limit` ascending-order workaround).
- Soft-deprecates the parent `query` verb in CLI help — describes the verbs as "pre-baked cuts for sanity / one-off greps" and points at `reading-logs.md`. Verbs themselves unchanged.

## Scope

Docs-only + one CLI help-text tweak. No code changes to the daemon, ingest path, or DB schema.

Bumps `@davstack/logs-server` to **1.3.2**.

## Test plan

- [ ] `docs/reading-logs.md` renders cleanly on GitHub
- [ ] `logs-server query --help` shows the new parent description
- [ ] `pnpm -F @davstack/logs-server build` succeeds
- [ ] After merge: `pnpm publish` from `packages/logs-server` (manual, CI not wired)

Closes #49.