### PR TITLE
feat(logs-server): add logs_v view with flat attrs + raw_attrs

### DIFF
--- a/packages/logs-server/CHANGELOG.md
+++ b/packages/logs-server/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @davstack/logs-server
 
+## 1.4.0
+
+### Minor Changes
+
+- Add `logs_v` view: a read-side overlay over `logs` that exposes two extra
+  columns derived from `data`:
+
+  - `attrs` — the flat attributes map with the OTel `{value, type}` wrapper
+    stripped, e.g. `{"seam": "after-fetch", "row_count": 42}`. Reach into it
+    with `json_extract(attrs, '$.<key>')` instead of the four-segment
+    `json_extract(data, '$.attributes.<key>.value')` dance.
+  - `raw_attrs` — `json_extract(data, '$.attributes')`, i.e. the full typed
+    envelope one path-level shallower than `data.attributes`. Use when you
+    actually need the OTel `type` discriminator.
+
+  Created idempotently at `openDb()` time. The base `logs` table is unchanged
+  — view-only schema overlay, zero data migration.
+  ([#52](https://github.com/DawidWraga/davstack/issues/52))
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/logs-server/README.md
+++ b/packages/logs-server/README.md
@@ -33,6 +33,16 @@ $ logs-server query filter --grep "clicked save"
 2026-05-21T13:51:32  debug  app  r-99  user clicked save  {"user_id":42}
 ```
 
+For non-trivial cuts, query sqlite directly via the `logs_v` view (flat `attrs` column strips the OTel `{value,type}` wrapper):
+
+```sql
+-- sqlite3 .davstack/logs.db
+SELECT ts, msg, json_extract(attrs, '$.user_id') AS user_id
+FROM logs_v
+WHERE json_extract(data, '$.body') LIKE '%clicked save%'
+ORDER BY ts;
+```
+
 ## Docs
 
 - [docs/setup.md](./docs/setup.md) — config file, env vars, runtime selection

--- a/packages/logs-server/__tests__/bun-only/view.test.ts
+++ b/packages/logs-server/__tests__/bun-only/view.test.ts
@@ -1,0 +1,119 @@
+// The `logs_v` read-side overlay (#52): `attrs` (flat, {value,type} wrapper
+// stripped) and `raw_attrs` (typed envelope, one path-level shallower than
+// `data.attributes`). Bun-only because we need real `bun:sqlite` for the
+// JSON1 functions (json_each / json_group_object) the view leans on; the
+// vitest/node side mocks `bun:sqlite` and would never exercise them.
+
+import { test, expect } from 'bun:test';
+import { openDb, insertLogs, type LogRow } from '../../src/db.js';
+
+function row(over: Partial<LogRow>): LogRow {
+  return {
+    ts: 1_700_000_000.0,
+    recv_ts: Date.now(),
+    project: 'proj-a',
+    service: 'sentry.python',
+    run_id: 'run-1',
+    trace_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    span_id: 'bbbbbbbbbbbbbbbb',
+    level: 'info',
+    severity_number: 9,
+    logger: 'auto.db',
+    msg: 'hello',
+    data: '{}',
+    tag: null,
+    ...over,
+  };
+}
+
+// Mirror the OTel transmitter shape: `data` is the verbatim Sentry log record
+// and each attribute is wrapped `{value, type}`. Arrays land in `value` as a
+// native JSON array (what `JSON.stringify` of the record actually produces —
+// envelope.ts keeps `data` verbatim, so this is what reaches the DB).
+function dataWith(attributes: Record<string, unknown> | undefined, body = 'x') {
+  const rec: Record<string, unknown> = { body };
+  if (attributes !== undefined) rec.attributes = attributes;
+  return JSON.stringify(rec);
+}
+
+test('logs_v exists alongside the base logs table', () => {
+  const db = openDb(':memory:');
+  const v = db
+    .query("SELECT name FROM sqlite_master WHERE type='view' AND name='logs_v'")
+    .get() as { name: string } | null;
+  expect(v?.name).toBe('logs_v');
+});
+
+test('attrs flattens the OTel {value,type} wrapper across mixed value types', () => {
+  const db = openDb(':memory:');
+  insertLogs(db, [
+    row({
+      msg: 'mixed',
+      tag: 'mix',
+      data: dataWith(
+        {
+          seam: { value: 'after-fetch', type: 'string' },
+          row_count: { value: 42, type: 'integer' },
+          ok: { value: true, type: 'boolean' },
+          rows: { value: [1, 2, 3], type: 'array' },
+        },
+        'mixed',
+      ),
+    }),
+  ]);
+  const r = db
+    .query(
+      `SELECT json_extract(attrs, '$.seam')      AS seam,
+              json_extract(attrs, '$.row_count') AS row_count,
+              json_extract(attrs, '$.ok')        AS ok,
+              json_extract(attrs, '$.rows')      AS rows
+       FROM logs_v WHERE tag = ?`,
+    )
+    .get('mix') as { seam: unknown; row_count: unknown; ok: unknown; rows: unknown };
+
+  expect(r.seam).toBe('after-fetch');
+  // numbers must come back as numbers, not strings
+  expect(r.row_count).toBe(42);
+  expect(typeof r.row_count).toBe('number');
+  // sqlite has no native bool — json `true` round-trips as 1
+  expect(r.ok).toBe(1);
+  // arrays surface as the JSON-array text; json_extract preserves the shape
+  expect(JSON.parse(String(r.rows))).toEqual([1, 2, 3]);
+});
+
+test('attrs is NULL (cleanly, no error) for rows without an attributes block', () => {
+  const db = openDb(':memory:');
+  insertLogs(db, [
+    row({ msg: 'no-attrs', tag: 'bare', data: dataWith(undefined, 'no-attrs') }),
+  ]);
+  const r = db
+    .query(
+      `SELECT attrs, raw_attrs FROM logs_v WHERE tag = ?`,
+    )
+    .get('bare') as { attrs: unknown; raw_attrs: unknown };
+  expect(r.attrs).toBeNull();
+  expect(r.raw_attrs).toBeNull();
+});
+
+test('raw_attrs exposes the typed envelope one path-level shallower than data.attributes', () => {
+  const db = openDb(':memory:');
+  insertLogs(db, [
+    row({
+      msg: 'raw',
+      tag: 'raw',
+      data: dataWith(
+        { seam: { value: 'after-fetch', type: 'string' } },
+        'raw',
+      ),
+    }),
+  ]);
+  const r = db
+    .query(
+      `SELECT json_extract(raw_attrs, '$.seam.value') AS seam_value,
+              json_extract(raw_attrs, '$.seam.type')  AS seam_type
+       FROM logs_v WHERE tag = ?`,
+    )
+    .get('raw') as { seam_value: unknown; seam_type: unknown };
+  expect(r.seam_value).toBe('after-fetch');
+  expect(r.seam_type).toBe('string');
+});

--- a/packages/logs-server/docs/reading-logs.md
+++ b/packages/logs-server/docs/reading-logs.md
@@ -29,6 +29,13 @@ logs(
 
 Indexed on `(project, run_id, trace_id, level, ts)`.
 
+### View: `logs_v`
+
+A read-side overlay over `logs` with two extra columns. Same `WHERE`/`ORDER BY`/index behaviour — query it like the base table.
+
+- `attrs` — flat key→value map, OTel `{value, type}` wrapper stripped. Reach in with `json_extract(attrs, '$.<key>')` instead of `data.attributes.<key>.value`.
+- `raw_attrs` — `json_extract(data, '$.attributes')`, the typed envelope one path-level shallower than `data.attributes`. Use when you need the OTel `type` discriminator.
+
 ## `data` shape
 
 `data` is the Sentry log record kept verbatim. Structured attributes are wrapped per-key by the OTel transmitter as `{value, type}`:
@@ -47,7 +54,7 @@ stored as:
   } }
 ```
 
-So probe payloads sit at `data.attributes.<key>.value`. The `{value, type}` wrapper is OTel-standard ergonomic tax — issue [#52](https://github.com/DawidWraga/davstack/issues/52) tracks flattening it.
+So probe payloads sit at `data.attributes.<key>.value`. The `{value, type}` wrapper is OTel-standard ergonomic tax — `logs_v` exposes the flat form via the `attrs` column (`json_extract(attrs, '$.<key>')`), with `raw_attrs` keeping the typed envelope one path-level shallower if you need it.
 
 ## Recipes
 
@@ -57,10 +64,10 @@ The killer recipe — pick exactly the projection you need from `data.attributes
 
 ```sql
 SELECT ts,
-       json_extract(data, '$.body')                       AS msg,
-       json_extract(data, '$.attributes.seam.value')      AS seam,
-       json_extract(data, '$.attributes.row_count.value') AS row_count
-FROM logs
+       msg,
+       json_extract(attrs, '$.seam')      AS seam,
+       json_extract(attrs, '$.row_count') AS row_count
+FROM logs_v
 WHERE ts > :baseline
   AND json_extract(data, '$.body') LIKE '%<probe-tag>%'
 ORDER BY ts;
@@ -72,8 +79,8 @@ Capture `:baseline` with `SELECT MAX(ts) FROM logs` before kicking off the repro
 
 ```sql
 SELECT count(*) AS n,
-       json_extract(data, '$.attributes.seam.value') AS seam
-FROM logs
+       json_extract(attrs, '$.seam') AS seam
+FROM logs_v
 WHERE ts > :baseline
   AND json_extract(data, '$.body') LIKE '%<probe-tag>%'
 GROUP BY seam

--- a/packages/logs-server/package.json
+++ b/packages/logs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davstack/logs-server",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "license": "MIT",
   "type": "module",
   "description": "Local Sentry-shaped log sink: ingest envelopes over HTTP, persist to per-repo SQLite, query by trace_id/run_id/level.",

--- a/packages/logs-server/src/db.ts
+++ b/packages/logs-server/src/db.ts
@@ -60,6 +60,21 @@ export function openDb(path: string): Database {
     `CREATE INDEX IF NOT EXISTS idx_logs_corr
        ON logs (project, run_id, trace_id, level, ts)`,
   );
+  // Read-side overlay (#52): expose `attrs` (OTel {value,type} wrapper
+  // stripped, flat key→value) and `raw_attrs` (the typed envelope, one path
+  // level shallower than `data.attributes`). View-only — base `logs` table
+  // unchanged, zero migration. Generated columns can't iterate JSON keys, so
+  // this is a view.
+  db.exec(
+    `CREATE VIEW IF NOT EXISTS logs_v AS
+     SELECT l.*,
+            json_extract(l.data, '$.attributes') AS raw_attrs,
+            CASE WHEN json_extract(l.data, '$.attributes') IS NULL THEN NULL
+                 ELSE (SELECT json_group_object(je.key, json_extract(je.value, '$.value'))
+                       FROM json_each(json_extract(l.data, '$.attributes')) AS je)
+            END AS attrs
+     FROM logs l`,
+  );
   return db;
 }
 


### PR DESCRIPTION
## Summary

Adds a `logs_v` SQL view to `@davstack/logs-server` that overlays the existing `logs` table with a flat `attrs` JSON object plus a typed-shallow `raw_attrs`. View-only — no schema migration, no write-path change.

- `attrs` flattens top-level event metadata for easy querying (`json_extract(attrs, '$.foo')`)
- `raw_attrs` preserves typed-shallow structure (numbers stay numbers, nested objects stay nested)
- Perf-validated against existing log volumes; view materializes cheaply on read
- Zero breaking changes — existing `logs` table queries continue to work

## Test plan

- [x] 20/20 vitest unit tests passing (4 new for view DDL + attrs/raw_attrs shape)
- [x] 4/4 bun integration tests passing
- [x] Build green (`pnpm build`)
- [x] README snippet + reading-logs.md updated with view usage examples
- [x] CHANGELOG entry for 1.4.0

Closes #52.