### PR TITLE
feat(logs-server)!: multi-DB log routing (2.0.0) + playwright-server --db flag (1.4.0)

### DIFF
--- a/packages/logs-server/CHANGELOG.md
+++ b/packages/logs-server/CHANGELOG.md
@@ -1,5 +1,53 @@
 # @davstack/logs-server
 
+## 2.0.0
+
+### Major Changes
+
+- Multi-DB log routing via the `davstack-logs.db` Sentry log attribute.
+  Transmitters that stamp the attribute on a log envelope cause the daemon to
+  dispatch that row to `.davstack/logs/<value>.db`; un-tagged emissions land
+  in `.davstack/logs/default.db`. The DB file IS the session boundary —
+  cross-session noise disappears, eval runs can co-locate logs with their
+  artifacts, and each session DB hosts its own SQL views with cleanup via
+  `rm`. ([#51](https://github.com/DawidWraga/davstack/issues/51))
+
+  **Breaking change: default DB path moved.** Pre-2.0 used a single
+  `<repo-root>/.davstack/logs.db`; 2.0+ uses
+  `<repo-root>/.davstack/logs/default.db`. Migration is one command:
+
+  ```bash
+  mv .davstack/logs.db .davstack/logs/default.db
+  ```
+
+  `logs-server check` flags the legacy file's presence and prints the exact
+  `mv` invocation. Existing scripts that hardcode `.davstack/logs.db` need
+  the path updated. Pinning the daemon to a single file with `--db <path>`,
+  `DIAG_DB`, or `dbPath` in config still works and disables the dispatch
+  layer — useful for eval runs that co-locate logs outside the repo's
+  standard layout.
+
+  Internals:
+
+  - New `DbHandleCache`: per-path `Database` handles with a 30-min idle close.
+  - New `resolveRoutedDb`: validates the routing attribute (lowercase alnum
+    plus `-`/`_`/`.`/`..` per segment; rejects absolute paths and repo-root
+    escapes; warn-once-per-value on reject, falls back to `default.db` so
+    misconfigured transmitters never lose rows).
+  - `envelope.ts` strips the routing attribute from `data` before persistence
+    so nothing inside a row records which DB it landed in.
+  - `prune` walks every `.davstack/logs/*.db` by default (unchanged semantics
+    versus the pre-2.0 "prune the one DB" behaviour); `--db <path>` pins to a
+    single file.
+
+  New docs:
+
+  - [`docs/transmitter-wiring.md`](./docs/transmitter-wiring.md) — the
+    3-line consumer addition to your existing `Sentry.init` + the runner-flag
+    side (`playwright-server --db=<name>`).
+  - [`docs/session-views.md`](./docs/session-views.md) — per-DB SQL views,
+    `dbg_` prefix convention, and the cleanup-via-`rm` lifecycle.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/logs-server/README.md
+++ b/packages/logs-server/README.md
@@ -9,7 +9,7 @@ Local Sentry-shaped app -> sqlite log sink.
 
 ## Why
 
-- **E2E tracability** Frontend + backend + workers POST to the same `.davstack/logs.db`; `--trace` follows requests across services.
+- **E2E tracability** Frontend + backend + workers POST to the same `.davstack/logs/default.db`; `--trace` follows requests across services.
 - **Zero infra.** Integrates into existing sentry logger client for auto-instrumentation and low effort setup.
 - **Optimized for Agents.** Compact one-row-per-line by default — coding agents read it without grouping passes.
 
@@ -36,7 +36,7 @@ $ logs-server query filter --grep "clicked save"
 For non-trivial cuts, query sqlite directly via the `logs_v` view (flat `attrs` column strips the OTel `{value,type}` wrapper):
 
 ```sql
--- sqlite3 .davstack/logs.db
+-- sqlite3 .davstack/logs/default.db
 SELECT ts, msg, json_extract(attrs, '$.user_id') AS user_id
 FROM logs_v
 WHERE json_extract(data, '$.body') LIKE '%clicked save%'
@@ -48,3 +48,5 @@ ORDER BY ts;
 - [docs/setup.md](./docs/setup.md) — config file, env vars, runtime selection
 - [docs/writing-logs.md](./docs/writing-logs.md) — transmitter setup per SDK
 - [docs/reading-logs.md](./docs/reading-logs.md) — sqlite schema, recipes, and CLI verb reference (sqlite is the recommended read path for any non-trivial diagnosis)
+- [docs/transmitter-wiring.md](./docs/transmitter-wiring.md) — route a session's logs to its own DB via the `davstack-logs.db` attribute
+- [docs/session-views.md](./docs/session-views.md) — per-DB SQL views, the high-value follow-up to multi-DB routing

--- a/packages/logs-server/__tests__/bun-only/db-cache.test.ts
+++ b/packages/logs-server/__tests__/bun-only/db-cache.test.ts
@@ -1,0 +1,110 @@
+// DbHandleCache holds one Database handle per absolute path. Bun-only because
+// it allocates real bun:sqlite databases — the cache hit/miss invariant is
+// only meaningful against the same Database instance the daemon uses to write.
+
+import { test, expect, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DbHandleCache } from '../../src/db-cache.js';
+import { insertLogs, type LogRow } from '../../src/db.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'db-cache-'));
+});
+
+function cleanup(d: string) {
+  try {
+    rmSync(d, { recursive: true, force: true });
+  } catch {}
+}
+
+function row(over: Partial<LogRow>): LogRow {
+  return {
+    ts: 1,
+    recv_ts: Date.now(),
+    project: 'p',
+    service: 's',
+    run_id: 'r',
+    trace_id: 't',
+    span_id: '',
+    level: 'info',
+    severity_number: 9,
+    logger: '',
+    msg: 'm',
+    data: '{}',
+    tag: null,
+    ...over,
+  };
+}
+
+test('getOrOpen returns the SAME handle on repeated calls (cache hit)', () => {
+  const cache = new DbHandleCache();
+  const p = join(dir, 'a.db');
+  const a = cache.getOrOpen(p);
+  const b = cache.getOrOpen(p);
+  expect(a).toBe(b);
+  cache.closeAll();
+  cleanup(dir);
+});
+
+test('different paths get different handles and materialize different files', () => {
+  const cache = new DbHandleCache();
+  const a = cache.getOrOpen(join(dir, 'one.db'));
+  const b = cache.getOrOpen(join(dir, 'two.db'));
+  expect(a).not.toBe(b);
+  insertLogs(a, [row({ msg: 'in-one' })]);
+  insertLogs(b, [row({ msg: 'in-two' })]);
+  expect((a.query('SELECT COUNT(*) c FROM logs').get() as { c: number }).c).toBe(1);
+  expect((b.query('SELECT COUNT(*) c FROM logs').get() as { c: number }).c).toBe(1);
+  cache.closeAll();
+  cleanup(dir);
+});
+
+test('opens through ensureParent — nested dirs are created on demand', () => {
+  const cache = new DbHandleCache();
+  const p = join(dir, 'deep', 'down', 'nested.db');
+  const db = cache.getOrOpen(p);
+  insertLogs(db, [row({})]);
+  expect(existsSync(p)).toBe(true);
+  cache.closeAll();
+  cleanup(dir);
+});
+
+test('first open runs the schema (logs table + logs_v view both exist)', () => {
+  const cache = new DbHandleCache();
+  const db = cache.getOrOpen(join(dir, 'schema.db'));
+  const tbl = db
+    .query("SELECT name FROM sqlite_master WHERE type='table' AND name='logs'")
+    .get() as { name: string } | null;
+  const view = db
+    .query("SELECT name FROM sqlite_master WHERE type='view' AND name='logs_v'")
+    .get() as { name: string } | null;
+  expect(tbl?.name).toBe('logs');
+  expect(view?.name).toBe('logs_v');
+  cache.closeAll();
+  cleanup(dir);
+});
+
+test('sweep closes handles idle past the timeout', () => {
+  const cache = new DbHandleCache({ idleCloseMs: 1_000 });
+  const p = join(dir, 'idle.db');
+  cache.getOrOpen(p);
+  expect(cache._sizeForTests()).toBe(1);
+  // simulate 5 minutes idle — the sweep is normally driven by the wall clock,
+  // but exposed-for-test lets us drive it deterministically.
+  cache._sweepForTests(Date.now() + 60 * 60 * 1000);
+  expect(cache._sizeForTests()).toBe(0);
+  cleanup(dir);
+});
+
+test('sweep retains handles still within idle window', () => {
+  const cache = new DbHandleCache({ idleCloseMs: 60 * 60 * 1000 });
+  const p = join(dir, 'fresh.db');
+  cache.getOrOpen(p);
+  cache._sweepForTests(Date.now() + 1_000);
+  expect(cache._sizeForTests()).toBe(1);
+  cache.closeAll();
+  cleanup(dir);
+});

--- a/packages/logs-server/__tests__/bun-only/db-walk.test.ts
+++ b/packages/logs-server/__tests__/bun-only/db-walk.test.ts
@@ -1,0 +1,43 @@
+// walkLogDbs walks <repo>/.davstack/logs/ recursively, returning every *.db
+// file. Used by `prune` and the daemon's hourly prune tick so cleanup stays
+// global without anyone having to track the active session-DB set.
+
+import { test, expect, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { walkLogDbs } from '../../src/db-walk.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'db-walk-'));
+});
+
+function touch(p: string): string {
+  mkdirSync(join(p, '..'), { recursive: true });
+  writeFileSync(p, '');
+  return p;
+}
+
+test('returns [] when the logs dir does not exist', () => {
+  expect(walkLogDbs(dir)).toEqual([]);
+});
+
+test('lists every *.db at the top level and below', () => {
+  const logs = join(dir, '.davstack', 'logs');
+  touch(join(logs, 'default.db'));
+  touch(join(logs, 'reorder-bug.db'));
+  touch(join(logs, 'feat', 'reorder.db'));
+  touch(join(logs, 'feat', 'sub', 'deep.db'));
+  // non-.db files are skipped
+  touch(join(logs, 'README.txt'));
+  const got = walkLogDbs(dir).sort();
+  expect(got).toEqual(
+    [
+      join(logs, 'default.db'),
+      join(logs, 'feat', 'reorder.db'),
+      join(logs, 'feat', 'sub', 'deep.db'),
+      join(logs, 'reorder-bug.db'),
+    ].sort(),
+  );
+});

--- a/packages/logs-server/__tests__/bun-only/dispatch.test.ts
+++ b/packages/logs-server/__tests__/bun-only/dispatch.test.ts
@@ -1,0 +1,129 @@
+// Dispatch seam: parse one envelope, fan its rows out to the right DB files
+// based on the `davstack-logs.db` attribute. Default-DB fallback covers both
+// the "attribute absent" and "attribute invalid" cases — bad routing must
+// not lose data, just redirect to the default bucket with a stderr warning.
+
+import { test, expect, beforeEach } from 'bun:test';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DbHandleCache } from '../../src/db-cache.js';
+import { dispatchIngest } from '../../src/ingest.js';
+import { _resetWarnOnceForTests } from '../../src/db-route.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dispatch-'));
+  _resetWarnOnceForTests();
+});
+
+const a = (value: unknown, type = 'string') => ({ value, type });
+
+function logRec(over: Record<string, unknown> = {}, attrs: Record<string, { value: unknown; type: string }> = {}) {
+  return {
+    timestamp: 1.0,
+    trace_id: 'a'.repeat(32),
+    level: 'info',
+    body: 'x',
+    attributes: { 'diag.project': a('p'), ...attrs },
+    ...over,
+  };
+}
+
+function envelope(items: unknown[]) {
+  return [
+    JSON.stringify({ sdk: { name: 'sentry.javascript.browser', version: '9.41.0' } }),
+    JSON.stringify({
+      type: 'log',
+      item_count: items.length,
+      content_type: 'application/vnd.sentry.items.log+json',
+    }),
+    JSON.stringify({ items }),
+  ].join('\n');
+}
+
+function countRows(path: string): number {
+  const cache = new DbHandleCache();
+  const db = cache.getOrOpen(path);
+  const n = (db.query('SELECT COUNT(*) c FROM logs').get() as { c: number }).c;
+  cache.closeAll();
+  return n;
+}
+
+test('fans rows out to the right DB by route attribute', () => {
+  const cache = new DbHandleCache();
+  const defaultDb = join(dir, '.davstack', 'logs', 'default.db');
+  const repoRoot = dir;
+
+  const raw = envelope([
+    logRec({ body: 'one' }, { 'davstack-logs.db': a('reorder-bug') }),
+    logRec({ body: 'two' }, { 'davstack-logs.db': a('reorder-bug') }),
+    logRec({ body: 'three' }, { 'davstack-logs.db': a('hotfix-7c') }),
+    logRec({ body: 'four' }),
+  ]);
+
+  const res = dispatchIngest(raw, { cache, defaultDbPath: defaultDb, repoRoot }, Date.now());
+  expect(res.accepted).toBe(4);
+
+  expect(countRows(join(dir, '.davstack', 'logs', 'reorder-bug.db'))).toBe(2);
+  expect(countRows(join(dir, '.davstack', 'logs', 'hotfix-7c.db'))).toBe(1);
+  expect(countRows(defaultDb)).toBe(1);
+  cache.closeAll();
+});
+
+test('invalid route values route to default + emit a stderr warning', () => {
+  const cache = new DbHandleCache();
+  const defaultDb = join(dir, '.davstack', 'logs', 'default.db');
+  const warned: string[] = [];
+
+  const raw = envelope([
+    logRec({ body: 'good' }, { 'davstack-logs.db': a('reorder-bug') }),
+    logRec({ body: 'bad' }, { 'davstack-logs.db': a('Bad Value') }),
+    logRec({ body: 'escape' }, { 'davstack-logs.db': a('../../../escaped') }),
+  ]);
+
+  const res = dispatchIngest(
+    raw,
+    { cache, defaultDbPath: defaultDb, repoRoot: dir, warn: (m) => warned.push(m) },
+    Date.now(),
+  );
+  expect(res.accepted).toBe(3);
+
+  expect(countRows(join(dir, '.davstack', 'logs', 'reorder-bug.db'))).toBe(1);
+  expect(countRows(defaultDb)).toBe(2);
+  expect(warned.length).toBe(2);
+  expect(warned[0]).toContain('Bad Value');
+  expect(warned[1]).toContain('escaped');
+  cache.closeAll();
+});
+
+test('all-default envelope creates the default DB file at the new path', () => {
+  const cache = new DbHandleCache();
+  const defaultDb = join(dir, '.davstack', 'logs', 'default.db');
+  const raw = envelope([logRec({ body: 'only' })]);
+
+  const res = dispatchIngest(raw, { cache, defaultDbPath: defaultDb, repoRoot: dir }, Date.now());
+  expect(res.accepted).toBe(1);
+  expect(existsSync(defaultDb)).toBe(true);
+  cache.closeAll();
+});
+
+test('persisted data has the route attribute stripped (regression guard)', () => {
+  const cache = new DbHandleCache();
+  const defaultDb = join(dir, '.davstack', 'logs', 'default.db');
+  const raw = envelope([
+    logRec(
+      { body: 'check-me' },
+      { 'davstack-logs.db': a('check-bug'), 'diag.run_id': a('r-9') },
+    ),
+  ]);
+
+  dispatchIngest(raw, { cache, defaultDbPath: defaultDb, repoRoot: dir }, Date.now());
+  const dbPath = join(dir, '.davstack', 'logs', 'check-bug.db');
+  const db = cache.getOrOpen(dbPath);
+  const row = db.query('SELECT data FROM logs').get() as { data: string };
+  const parsed = JSON.parse(row.data) as { attributes: Record<string, unknown> };
+  expect(parsed.attributes['davstack-logs.db']).toBeUndefined();
+  expect(parsed.attributes['diag.run_id']).toEqual({ value: 'r-9', type: 'string' });
+  cache.closeAll();
+});

--- a/packages/logs-server/__tests__/check.test.ts
+++ b/packages/logs-server/__tests__/check.test.ts
@@ -229,6 +229,44 @@ test('suppressStaleRowsFix keeps hint when db has zero lifetime rows', () => {
   expect(db.fix).toMatch(/no rows in last/);
 });
 
+test('runCheck flags a legacy .davstack/logs.db file with mv hint', async () => {
+  const cwd = tmp();
+  const { mkdirSync } = await import('node:fs');
+  mkdirSync(join(cwd, '.davstack'), { recursive: true });
+  writeFileSync(join(cwd, '.davstack', 'logs.db'), '');
+  // Make findRepoRoot stop here.
+  writeFileSync(join(cwd, 'package.json'), `{"name":"tmp"}`);
+
+  const cap = captureStdout();
+  const code = await runCheck({
+    cwd,
+    json: true,
+    host: '127.0.0.1',
+    port: 65535,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = cap.restore();
+  expect(code).toBe(0);
+  const result = JSON.parse(out);
+  expect(result.legacy.present).toBe(true);
+  expect(result.legacy.fix).toMatch(/mv /);
+  expect(result.legacy.fix).toMatch(/default\.db/);
+});
+
+test('runCheck does NOT add the legacy row when no logs.db exists', async () => {
+  const cwd = tmp();
+  writeFileSync(join(cwd, 'package.json'), `{"name":"tmp"}`);
+  const cap = captureStdout();
+  await runCheck({
+    cwd,
+    host: '127.0.0.1',
+    port: 65535,
+    db: join(cwd, 'missing.sqlite'),
+  });
+  const out = stripAnsi(cap.restore());
+  expect(out).not.toMatch(/Legacy DB/);
+});
+
 test('suppressStaleRowsFix drops stale hint when daemon is down', () => {
   const db = {
     ok: true,

--- a/packages/logs-server/__tests__/db-route.test.ts
+++ b/packages/logs-server/__tests__/db-route.test.ts
@@ -1,0 +1,81 @@
+// Validation pipeline for the `davstack-logs.db` routing attribute.
+// Pure logic — no bun:sqlite, no filesystem writes — kept in vitest so it
+// runs on the same wire as the rest of the node-side suite.
+
+import { test, expect, beforeEach, vi } from 'vitest';
+import { resolve } from 'node:path';
+import { resolveRoutedDb, _resetWarnOnceForTests } from '../src/db-route.js';
+
+const REPO = process.platform === 'win32' ? 'C:\\proj' : '/proj';
+const join = (...p: string[]) => resolve(REPO, ...p);
+
+beforeEach(() => {
+  _resetWarnOnceForTests();
+});
+
+const VALID: Array<[string, string]> = [
+  ['reorder-bug', join('.davstack', 'logs', 'reorder-bug.db')],
+  ['feat/reorder', join('.davstack', 'logs', 'feat', 'reorder.db')],
+  ['reorder-bug.db', join('.davstack', 'logs', 'reorder-bug.db')],
+  ['../sandbox/x', join('.davstack', 'sandbox', 'x.db')],
+  ['../../my-evals/run-1/logs', join('my-evals', 'run-1', 'logs.db')],
+  ['x_y_z', join('.davstack', 'logs', 'x_y_z.db')],
+];
+
+for (const [input, expected] of VALID) {
+  test(`accepts ${JSON.stringify(input)} → ${expected}`, () => {
+    const r = resolveRoutedDb(input, REPO);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.path).toBe(expected);
+  });
+}
+
+const INVALID: Array<[string, string]> = [
+  ['../../../escaped', 'escapes repo'],
+  ['/etc/passwd', 'absolute'],
+  ['C:\\evil', 'absolute'],
+  ['Reorder-Bug', 'charset'],
+  ['reorder bug', 'charset'],
+  ['', 'empty'],
+  ['-leading-hyphen', 'charset'],
+  ['_leading-underscore', 'charset'],
+  ['a//b', 'charset'],
+  ['a/.hidden/b', 'charset'],
+];
+
+for (const [input, reasonHint] of INVALID) {
+  test(`rejects ${JSON.stringify(input)} (${reasonHint})`, () => {
+    const r = resolveRoutedDb(input, REPO);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason.toLowerCase()).toContain(reasonHint);
+  });
+}
+
+test('".db" suffix idempotent', () => {
+  const a = resolveRoutedDb('foo', REPO);
+  const b = resolveRoutedDb('foo.db', REPO);
+  expect(a.ok && b.ok && a.path === b.path).toBe(true);
+});
+
+test('per-segment validation — `..` and `.` allowed as traversal tokens', () => {
+  expect(resolveRoutedDb('../sandbox/x', REPO).ok).toBe(true);
+  expect(resolveRoutedDb('./x', REPO).ok).toBe(true);
+});
+
+test('warns-once per unique invalid value', () => {
+  const warn = vi.fn();
+  resolveRoutedDb('Bad', REPO, { warn });
+  resolveRoutedDb('Bad', REPO, { warn });
+  resolveRoutedDb('Bad', REPO, { warn });
+  expect(warn).toHaveBeenCalledTimes(1);
+  resolveRoutedDb('Other-Bad', REPO, { warn });
+  expect(warn).toHaveBeenCalledTimes(2);
+});
+
+test('warn message includes the value and a reason hint', () => {
+  const warn = vi.fn();
+  resolveRoutedDb('Reorder-Bug', REPO, { warn });
+  const msg = warn.mock.calls[0]?.[0] as string;
+  expect(msg).toContain('Reorder-Bug');
+  expect(msg.toLowerCase()).toContain('default.db');
+});

--- a/packages/logs-server/__tests__/envelope.test.ts
+++ b/packages/logs-server/__tests__/envelope.test.ts
@@ -111,3 +111,39 @@ test('empty / whitespace body never throws and yields nothing', () => {
     expect(skipped).toBe(0);
   }
 });
+
+// Multi-DB routing: the `davstack-logs.db` attribute is the wire that tells the
+// daemon which file to drop the row into. It is consumed by the dispatch loop
+// and stripped before persistence — the DB file is the session indicator, and
+// nothing inside the row should record which bucket it landed in.
+
+test('surfaces the davstack-logs.db attribute as routeDb', () => {
+  const { rows } = parseEnvelope(
+    envelope([log({ attributes: { 'davstack-logs.db': a('reorder-bug') } })]),
+  );
+  expect(rows[0].routeDb).toBe('reorder-bug');
+});
+
+test('strips the davstack-logs.db attribute from persisted data', () => {
+  const { rows } = parseEnvelope(
+    envelope([
+      log({
+        body: 'p',
+        attributes: {
+          'davstack-logs.db': a('reorder-bug'),
+          'diag.project': a('proj'),
+          'diag.run_id': a('r-1'),
+        },
+      }),
+    ]),
+  );
+  const persisted = JSON.parse(rows[0].data) as { attributes: Record<string, unknown> };
+  expect(persisted.attributes['davstack-logs.db']).toBeUndefined();
+  expect(persisted.attributes['diag.project']).toEqual(a('proj'));
+  expect(persisted.attributes['diag.run_id']).toEqual(a('r-1'));
+});
+
+test('routeDb is undefined when no attribute is set (back-compat baseline)', () => {
+  const { rows } = parseEnvelope(envelope([log()]));
+  expect(rows[0].routeDb).toBeUndefined();
+});

--- a/packages/logs-server/docs/reading-logs.md
+++ b/packages/logs-server/docs/reading-logs.md
@@ -1,10 +1,31 @@
 # Reading logs
 
 ```bash
-sqlite3 .davstack/logs.db
+sqlite3 .davstack/logs/default.db
 ```
 
 Structured probe attributes live inside `data` (a JSON blob), so any non-trivial cut needs `json_extract`. The CLI `query` verbs are pre-baked cuts for sanity checks; reach past them as soon as you want structured payloads, compound predicates, or aggregation.
+
+## Choosing a DB
+
+The daemon writes one file per "session" under `.davstack/logs/`:
+
+```
+.davstack/logs/
+  default.db            ← un-tagged emissions
+  reorder-bug.db        ← runs started with --db=reorder-bug
+  hotfix-7c.db
+```
+
+`default.db` is the catch-all — everything lands here unless the transmitter stamps a `davstack-logs.db` attribute. Named sibling files appear when a runner (e.g. `playwright-server --db=reorder-bug`) routes its session. The file IS the session boundary; nothing inside the row records which bucket it landed in.
+
+Open the right one:
+
+```bash
+sqlite3 .davstack/logs/reorder-bug.db
+```
+
+Wiring the routing attribute end-to-end: see [transmitter-wiring.md](./transmitter-wiring.md). Per-session SQL views: see [session-views.md](./session-views.md).
 
 ## Schema
 

--- a/packages/logs-server/docs/session-views.md
+++ b/packages/logs-server/docs/session-views.md
@@ -1,0 +1,96 @@
+# Per-session SQL views
+
+When a debugging session has its own DB file (see [transmitter-wiring.md](./transmitter-wiring.md)), you can persist SQL views inside that file — tailored to the bug you're hunting, isolated from the rest of the project's logs, and cleaned up by `rm`-ing the file when you're done.
+
+This is the high-value reason multi-DB ships at all. With a single global DB, every `CREATE VIEW` would pollute every future query; per-session DBs make views safe to create freely.
+
+## The pattern
+
+Open the session DB and define a probe-vocabulary view at the start of the session:
+
+```bash
+sqlite3 .davstack/logs/reorder-bug.db
+```
+
+```sql
+CREATE VIEW IF NOT EXISTS dbg_probe AS
+SELECT id, ts, level,
+       json_extract(data, '$.body')         AS msg,
+       json_extract(attrs, '$.seam')        AS seam,
+       json_extract(attrs, '$.nextDims')    AS nextDims,
+       json_extract(attrs, '$.prevDims')    AS prevDims,
+       json_extract(attrs, '$.columnOrder') AS columnOrder
+FROM logs_v
+WHERE json_extract(data, '$.body') LIKE '%[colorder-probe]%';
+```
+
+Then every subsequent query is:
+
+```sql
+SELECT ts, seam, columnOrder FROM dbg_probe ORDER BY ts;
+```
+
+One cheap reference per query — no JSON-extract repetition, no probe-tag string repetition, no risk of typos drifting between queries.
+
+## Useful view shapes
+
+### Before/after a fix
+
+Capture the wall clock right before applying a candidate fix, then split the timeline:
+
+```sql
+CREATE VIEW dbg_pre_fix  AS SELECT * FROM dbg_probe WHERE ts <  1716480000;
+CREATE VIEW dbg_post_fix AS SELECT * FROM dbg_probe WHERE ts >= 1716480000;
+```
+
+Compare side-by-side with two query windows.
+
+### Scope to one run within the session
+
+A session DB often holds rows from several `run_id`s (multiple page-loads). Scope to one:
+
+```sql
+CREATE VIEW dbg_this_run AS SELECT * FROM dbg_probe WHERE run_id = 'r-XYZ';
+```
+
+### Pivot fixed-shape probes into columns
+
+If your probes always emit the same attribute set, rotate them into typed columns for ergonomic `WHERE`:
+
+```sql
+CREATE VIEW dbg_seam_pivot AS
+SELECT ts,
+       json_extract(attrs, '$.seam')                                   AS seam,
+       CAST(json_extract(attrs, '$.row_count') AS INTEGER)             AS row_count,
+       json_extract(attrs, '$.ok')                                     AS ok
+FROM logs_v
+WHERE json_extract(data, '$.body') LIKE '%[probe]%';
+```
+
+Then `WHERE row_count > 100` works without an inline `json_extract` in every query.
+
+## Lifecycle
+
+- Views persist across `sqlite3` invocations within the same DB file — write them once at the start of a session.
+- Drop just one view in a live session: `DROP VIEW dbg_probe;`.
+- Clean up everything: `rm .davstack/logs/<name>.db`. The DB file goes; the views go with it.
+
+## Naming convention: `dbg_` prefix
+
+Prefix every session-scoped view with `dbg_`. Two benefits:
+
+- Easy to spot and drop in bulk:
+  ```sql
+  SELECT name FROM sqlite_master WHERE type='view' AND name LIKE 'dbg_%';
+  ```
+- Won't collide with the shipped `logs_v` view that exists in every DB.
+
+## Anti-patterns
+
+- **Don't `CREATE VIEW` in `default.db`** (or any sessionless DB). That view becomes global noise across every future session that lands rows in the same file.
+- **Don't rely on `CREATE TEMP VIEW`** — temp views are per-connection and evaporate the moment you exit `sqlite3`. The whole point of session DBs is that the view lives with the rows, accessible from every subsequent connection.
+- **Don't try to share views across session DBs.** SQLite views are file-local. If you find yourself wanting that, the underlying query belongs in your skill / agent prompt, not in the DB.
+
+## Agent usage
+
+If you're an agent iterating in a session DB, the first query of the iteration is `CREATE VIEW dbg_<name> IF NOT EXISTS …` for whatever projection you'll keep hitting; every subsequent query reads from it. This is the agent-side hygiene equivalent of "stash the projection once, reuse it everywhere" — saves tokens, makes the actual investigation queries shorter, and the leftover view becomes the artifact a human can re-open later.

--- a/packages/logs-server/docs/setup.md
+++ b/packages/logs-server/docs/setup.md
@@ -8,8 +8,10 @@
 export default {
   port: 5181,
   host: "127.0.0.1",
-  dbPath: ".davstack/logs.db", // relative to repo root
-  pruneDays: 14,                // 0 disables background prune
+  // dbPath pins a SINGLE file (back-compat / external eval-runner co-location).
+  // Omit for the default per-session layout under .davstack/logs/.
+  // dbPath: ".davstack/logs/default.db",
+  pruneDays: 14,                // 0 disables background prune; walks every .davstack/logs/*.db
   // cors: "*",                 // browser CORS policy (see §7); default permissive
 }
 ```
@@ -17,6 +19,8 @@ export default {
 The daemon walks up from cwd to find the repo root (git root → workspace marker → `package.json` with workspaces).
 
 Per-key precedence: **CLI flag > env var (`DIAG_PORT` / `DIAG_DB` / `DIAG_HOST`) > config file > built-in default.**
+
+Default DB layout (since 2.0.0): `<repo-root>/.davstack/logs/default.db`, with per-session sibling files (`reorder-bug.db`, `hotfix-7c.db`, …) created on demand when a transmitter sets the `davstack-logs.db` attribute. Setting `dbPath` (or `DIAG_DB`, or `--db <file>`) pins the daemon to a single file and disables the dispatch layer — useful for eval runs that want a co-located log file outside the repo's standard layout.
 
 Skip the manual edit with `pnpm exec davstack-init --tools=logs-server` (scaffolds the config + appends `.davstack/*` / `!.davstack/config/` to `.gitignore`).
 

--- a/packages/logs-server/docs/transmitter-wiring.md
+++ b/packages/logs-server/docs/transmitter-wiring.md
@@ -1,0 +1,71 @@
+# Routing logs to a per-session DB
+
+By default everything lands in `.davstack/logs/default.db`. If you want a session's logs to land in its own file (`reorder-bug.db`, `hotfix-7c.db`, etc.) — for cross-session isolation, per-session SQL views (see [session-views.md](./session-views.md)), or eval co-location — the transmitter stamps one extra attribute on each log envelope. The daemon dispatches.
+
+## Wire shape
+
+The Sentry log envelope already carries a key-value `attributes` map. The daemon reads attribute `davstack-logs.db`:
+
+- present → resolve + route to `.davstack/logs/<value>.db`
+- absent → route to `.davstack/logs/default.db`
+
+The daemon strips the attribute before persisting the row, so the file IS the session indicator and nothing inside the row records which bucket it landed in.
+
+## Consumer side: 3 lines in `sentry.ts`
+
+Where you already stamp `diag.run_id` and friends in `beforeSendLog`, add the routing key:
+
+```ts
+// near the top, after diagRunId is captured
+const davstackDb = (window as { __davstack_db?: string }).__davstack_db ?? null
+
+Sentry.init({
+  // … your existing init …
+  beforeSendLog(log) {
+    return {
+      ...log,
+      attributes: {
+        ...log.attributes,
+        "diag.project": DIAG_PROJECT,
+        "diag.run_id": diagRunId,
+        ...(davstackDb && { "davstack-logs.db": davstackDb }),
+      },
+    }
+  },
+})
+```
+
+No transport rewrite, no DSN change, no integration package. Existing CORS / proxy / Sentry SDK behaviour is unchanged — the wire shape is the same envelope you already POST.
+
+## Runner side (browser)
+
+`window.__davstack_db` is the boot-time global. Whoever launches the page sets it before the app's bundle runs.
+
+### Playwright
+
+`playwright-server --db=<value>` seeds the global via `page.addInitScript` before navigation. Nothing else to do — the spec just runs and its logs land in `.davstack/logs/<value>.db`.
+
+```bash
+playwright-server --db=reorder-bug e2e/reorder-flow.spec.ts
+```
+
+### Dev server / manual reproduction
+
+In the browser devtools console, before reloading the page:
+
+```js
+window.__davstack_db = "reorder-bug"
+```
+
+Then reload. Logs from this tab will route to `reorder-bug.db` until you clear the value or close the tab.
+
+## Naming rules
+
+- Lowercase alnum + `-` / `_`, no spaces (`reorder-bug`, `feat_x`, `hotfix-7c`).
+- Slashes create subdirectories (`feat/reorder` → `.davstack/logs/feat/reorder.db`).
+- `..` traversal is allowed but the resolved path must stay inside the repo root (used by eval runners to co-locate logs with test artifacts).
+- Invalid values do not fail — the daemon prints one stderr warning per unique bad value and routes the rows to `default.db` so emissions are never lost.
+
+## Backend (Node) is deferred
+
+This wire is browser-only today. Backend processes continue to route to `default.db` regardless of attribute (their logs cross the daemon via separate transmitters). When backend-side routing lands, the same attribute will work — no daemon change needed.

--- a/packages/logs-server/docs/transmitter-wiring.md
+++ b/packages/logs-server/docs/transmitter-wiring.md
@@ -17,7 +17,7 @@ Where you already stamp `diag.run_id` and friends in `beforeSendLog`, add the ro
 
 ```ts
 // near the top, after diagRunId is captured
-const davstackDb = (window as { __davstack_db?: string }).__davstack_db ?? null
+const davstackDb = (window as Window & { __davstack_db?: string }).__davstack_db ?? null
 
 Sentry.init({
   // … your existing init …

--- a/packages/logs-server/docs/writing-logs.md
+++ b/packages/logs-server/docs/writing-logs.md
@@ -19,6 +19,12 @@ Two rules:
 
 Cheap to write, fast to query later (`json_extract(data, '$.url')` in [reading-logs.md](./reading-logs.md)).
 
+## Routing a session's logs to its own DB
+
+Default: every emission lands in `.davstack/logs/default.db`. If you want a particular debug session, eval run, or repro to live in its own file (cleanup-via-`rm`, isolated views, no cross-session noise), the transmitter just stamps one attribute on each log. The daemon dispatches.
+
+See [transmitter-wiring.md](./transmitter-wiring.md) for the 3-line `sentry.ts` snippet and the runner-flag side (`playwright-server --db=<name>`). Once routed, [session-views.md](./session-views.md) shows the high-value follow-up: per-DB SQL views tailored to the bug you're hunting.
+
 ## What you DON'T put in each call
 
 - **`run_id`** — already stamped globally by your `Sentry.init`'s `beforeSendLog` ([setup.md §2](./setup.md#js%2Fts)). One per page-load / process.

--- a/packages/logs-server/package.json
+++ b/packages/logs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davstack/logs-server",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "license": "MIT",
   "type": "module",
   "description": "Local Sentry-shaped log sink: ingest envelopes over HTTP, persist to per-repo SQLite, query by trace_id/run_id/level.",

--- a/packages/logs-server/src/check.ts
+++ b/packages/logs-server/src/check.ts
@@ -11,7 +11,11 @@
 import { existsSync, statSync } from 'node:fs';
 import { findRepoRoot, findToolConfig } from '@davstack/cli-utils/config';
 import { loadConfig } from './config.js';
-import { dbPath as resolveDbPath } from './paths.js';
+import {
+  dbPath as resolveDbPath,
+  defaultDbPathForRepo,
+  legacyDbPathForRepo,
+} from './paths.js';
 
 const REQUIRED_NODE_MAJOR = 20;
 
@@ -21,6 +25,7 @@ type CheckResult = {
   daemon: { ok: boolean; running: boolean; url: string; fix?: string };
   config: { ok: boolean; source?: string; repoRoot?: string };
   db: { ok: boolean; path: string; exists: boolean; totalRows?: number; recentRows?: number; recentWindowMs: number; fix?: string };
+  legacy: { ok: boolean; present: boolean; path: string; fix?: string };
 };
 
 function checkNode(): CheckResult['node'] {
@@ -154,8 +159,14 @@ export async function runCheck(opts: {
   const host = opts.host ?? process.env.DIAG_HOST ?? cfg.host ?? '127.0.0.1';
   const envPort = process.env.DIAG_PORT ? Number(process.env.DIAG_PORT) : undefined;
   const port = opts.port ?? envPort ?? cfg.port ?? 7077;
+  const repoRoot = cfg._repoRoot ?? findRepoRoot(cwd);
   const configDbPath = cfg._dbPathResolved ?? cfg.dbPath;
-  const file = resolveDbPath(opts.db ?? configDbPath);
+  // No --db / config override → use the new default `<repo>/.davstack/logs/default.db`.
+  const file = opts.db
+    ? resolveDbPath(opts.db)
+    : configDbPath
+      ? resolveDbPath(configDbPath)
+      : defaultDbPathForRepo(repoRoot);
 
   const result: CheckResult = {
     ok: true,
@@ -163,6 +174,7 @@ export async function runCheck(opts: {
     daemon: await checkDaemon(host, port),
     config: checkConfig(cwd),
     db: await checkDb(file),
+    legacy: checkLegacy(repoRoot),
   };
   // Node is the only load-bearing gate. Daemon/db are info — agents inspect
   // and act accordingly.
@@ -197,9 +209,25 @@ export async function runCheck(opts: {
   if (!result.daemon.running && result.daemon.fix) {
     lines.push(`                          ${result.daemon.fix}`);
   }
+  if (result.legacy.present) {
+    lines.push(`  ${rowGlyph({ ok: true, fix: result.legacy.fix })} Legacy DB            ${result.legacy.path}`);
+    lines.push(`                          ${result.legacy.fix}`);
+  }
   lines.push('');
   process.stdout.write(lines.join('\n'));
   return result.ok ? 0 : 1;
+}
+
+function checkLegacy(repoRoot: string): CheckResult['legacy'] {
+  const legacy = legacyDbPathForRepo(repoRoot);
+  if (!existsSync(legacy)) return { ok: true, present: false, path: legacy };
+  const target = defaultDbPathForRepo(repoRoot);
+  return {
+    ok: true,
+    present: true,
+    path: legacy,
+    fix: `legacy single-DB file present — move it: \`mv ${legacy} ${target}\``,
+  };
 }
 
 export type { CheckResult };

--- a/packages/logs-server/src/db-cache.ts
+++ b/packages/logs-server/src/db-cache.ts
@@ -1,0 +1,80 @@
+// Per-path Database handle pool for the multi-DB ingest seam. Each unique
+// absolute path opens at most one Database; subsequent ingests reuse it. An
+// idle sweeper closes handles untouched for `idleCloseMs` — memory pressure
+// is negligible (just a fd + WAL state) but unbounded growth would still bite
+// a long-running daemon with thousands of one-off session DBs.
+//
+// Schema-boot is delegated to openDb() — every new DB file gets the same
+// logs table + correlation index + logs_v view on first open, without any
+// caller having to remember.
+
+import type { Database } from 'bun:sqlite';
+import { openDb } from './db.js';
+import { ensureParent } from './paths.js';
+
+const DEFAULT_IDLE_CLOSE_MS = 30 * 60 * 1000;
+const DEFAULT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+type Entry = { db: Database; lastUsed: number };
+
+export class DbHandleCache {
+  private handles = new Map<string, Entry>();
+  private readonly idleCloseMs: number;
+  private timer?: ReturnType<typeof setInterval>;
+
+  constructor(opts: { idleCloseMs?: number } = {}) {
+    this.idleCloseMs = opts.idleCloseMs ?? DEFAULT_IDLE_CLOSE_MS;
+  }
+
+  getOrOpen(absPath: string): Database {
+    const cached = this.handles.get(absPath);
+    if (cached) {
+      cached.lastUsed = Date.now();
+      return cached.db;
+    }
+    ensureParent(absPath);
+    const db = openDb(absPath);
+    this.handles.set(absPath, { db, lastUsed: Date.now() });
+    return db;
+  }
+
+  startIdleSweeper(intervalMs: number = DEFAULT_SWEEP_INTERVAL_MS): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this._sweepForTests(Date.now()), intervalMs);
+    // unref so a hung daemon shutdown isn't blocked on the timer
+    (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  stopIdleSweeper(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  closeAll(): void {
+    this.stopIdleSweeper();
+    for (const [, entry] of this.handles) {
+      try {
+        entry.db.close();
+      } catch {}
+    }
+    this.handles.clear();
+  }
+
+  _sweepForTests(now: number): void {
+    const cutoff = now - this.idleCloseMs;
+    for (const [path, entry] of this.handles) {
+      if (entry.lastUsed < cutoff) {
+        try {
+          entry.db.close();
+        } catch {}
+        this.handles.delete(path);
+      }
+    }
+  }
+
+  _sizeForTests(): number {
+    return this.handles.size;
+  }
+}

--- a/packages/logs-server/src/db-route.ts
+++ b/packages/logs-server/src/db-route.ts
@@ -1,0 +1,88 @@
+// Resolve a `davstack-logs.db` routing value (the per-session/per-bug log DB
+// hint emitted by the transmitter) into an absolute path on disk.
+//
+// Inputs are untrusted: the value originates in browser code and rides through
+// the Sentry envelope as an opaque attribute. The pipeline therefore must
+// reject anything pathological (absolute paths, drive prefixes, mixed case,
+// stray whitespace) and contain the result inside the repo root — including
+// when the `..` traversal escape is used for eval co-location.
+//
+// On reject: caller routes to default.db. We warn-once per unique invalid
+// value to avoid spam from a misconfigured transmitter looping the same
+// envelope thousands of times.
+
+import { resolve, sep } from 'node:path';
+
+export type RouteResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: string };
+
+export type RouteOptions = {
+  warn?: (msg: string) => void;
+};
+
+const SEGMENT_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const ABS_PREFIXES = [/^\//, /^[A-Za-z]:/];
+
+const warnedValues = new Set<string>();
+
+export function _resetWarnOnceForTests(): void {
+  warnedValues.clear();
+}
+
+function classify(value: string): { ok: true } | { ok: false; reason: string } {
+  if (value.length === 0) return { ok: false, reason: 'empty value' };
+  for (const re of ABS_PREFIXES) {
+    if (re.test(value)) return { ok: false, reason: 'absolute path not allowed' };
+  }
+  // The final segment may end in `.db` (idempotency for users who type the
+  // suffix). Strip it for charset purposes; reappended in resolveRoutedDb.
+  const segments = value.replace(/\\/g, '/').split('/');
+  if (segments.length > 0) {
+    const last = segments[segments.length - 1];
+    if (last.endsWith('.db')) segments[segments.length - 1] = last.slice(0, -3);
+  }
+  for (const seg of segments) {
+    if (seg === '.' || seg === '..') continue;
+    if (!SEGMENT_RE.test(seg)) {
+      return { ok: false, reason: `charset (segment "${seg}" must match ${SEGMENT_RE})` };
+    }
+  }
+  return { ok: true };
+}
+
+export function resolveRoutedDb(
+  value: string,
+  repoRoot: string,
+  opts: RouteOptions = {},
+): RouteResult {
+  const verdict = classify(value);
+  if (!verdict.ok) {
+    return warnOnceAndReject(value, verdict.reason, opts);
+  }
+
+  const withSuffix = value.endsWith('.db') ? value : `${value}.db`;
+  const abs = resolve(repoRoot, '.davstack', 'logs', withSuffix);
+
+  // Containment: the resolved path must live inside the repo root. The trailing
+  // sep guards against `<repoRoot>/foo` matching `<repoRoot>foo-evil`.
+  const rootWithSep = repoRoot.endsWith(sep) ? repoRoot : repoRoot + sep;
+  if (!abs.startsWith(rootWithSep) && abs !== repoRoot) {
+    return warnOnceAndReject(value, 'escapes repo root', opts);
+  }
+  return { ok: true, path: abs };
+}
+
+function warnOnceAndReject(
+  value: string,
+  reason: string,
+  opts: RouteOptions,
+): RouteResult {
+  if (!warnedValues.has(value)) {
+    warnedValues.add(value);
+    const msg = `[logs-server] invalid db "${value}": ${reason}; routing to default.db`;
+    if (opts.warn) opts.warn(msg);
+    else process.stderr.write(msg + '\n');
+  }
+  return { ok: false, reason };
+}

--- a/packages/logs-server/src/db-walk.ts
+++ b/packages/logs-server/src/db-walk.ts
@@ -1,0 +1,38 @@
+// Enumerate every session DB file under `<repoRoot>/.davstack/logs/`.
+// Used by the daemon's background prune tick and the `prune` CLI verb so
+// "prune the logs" stays semantically global — same as the pre-2.0 single-DB
+// behavior — without anyone tracking the live set of session names.
+
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { DEFAULT_DB_DIR } from './paths.js';
+
+export function walkLogDbs(repoRoot: string): string[] {
+  const root = join(repoRoot, DEFAULT_DB_DIR);
+  const out: string[] = [];
+  walk(root, out);
+  return out;
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return; // dir doesn't exist yet — fine, nothing to prune
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) {
+      walk(full, out);
+    } else if (name.endsWith('.db')) {
+      out.push(full);
+    }
+  }
+}

--- a/packages/logs-server/src/envelope.ts
+++ b/packages/logs-server/src/envelope.ts
@@ -8,9 +8,14 @@
 
 import type { LogRow } from './db.js';
 
-export type ParsedLog = Omit<LogRow, 'recv_ts'>;
+// `routeDb` is a daemon-internal field — it drives multi-DB dispatch and is
+// stripped from the row's `data` before persistence (the file IS the session
+// indicator). Never written to the `logs` table.
+export type ParsedLog = Omit<LogRow, 'recv_ts'> & { routeDb?: string };
 
 type Attr = { value?: unknown; type?: string };
+
+const ROUTE_DB_ATTR = 'davstack-logs.db';
 
 function strOr(v: unknown, d: string): string {
   return v === undefined || v === null ? d : String(v);
@@ -36,6 +41,20 @@ function toRow(rec: Record<string, unknown>, sdkName: string, envTraceId: string
   const attrs = (rec.attributes as Record<string, Attr> | undefined) ?? undefined;
   const sev = rec.severity_number;
   const diagTag = attrVal(attrs, 'diag.tag');
+
+  // Pull the routing hint and remove it before serializing — the persisted
+  // record carries no trace of which DB it landed in. Operate on a shallow
+  // copy of `attributes` so we don't mutate the caller's object.
+  let routeDb: string | undefined;
+  let recForPersist: Record<string, unknown> = rec;
+  if (attrs && ROUTE_DB_ATTR in attrs) {
+    const v = attrs[ROUTE_DB_ATTR]?.value;
+    if (typeof v === 'string' && v.length > 0) routeDb = v;
+    const { [ROUTE_DB_ATTR]: _drop, ...rest } = attrs;
+    void _drop;
+    recForPersist = { ...rec, attributes: rest };
+  }
+
   return {
     ts: typeof rec.timestamp === 'number' ? rec.timestamp : Number(rec.timestamp) || 0,
     project: strOr(attrVal(attrs, 'diag.project'), ''),
@@ -47,8 +66,9 @@ function toRow(rec: Record<string, unknown>, sdkName: string, envTraceId: string
     severity_number: typeof sev === 'number' && Number.isFinite(sev) ? sev : 0,
     logger: strOr(attrVal(attrs, 'sentry.origin'), ''),
     msg: stripStyledLogPrefix(strOr(rec.body, '')),
-    data: JSON.stringify(rec), // verbatim — round-trips deep-equal
+    data: JSON.stringify(recForPersist), // verbatim — minus the routing key
     tag: diagTag === undefined || diagTag === null ? null : String(diagTag),
+    routeDb,
   };
 }
 

--- a/packages/logs-server/src/index.ts
+++ b/packages/logs-server/src/index.ts
@@ -176,32 +176,65 @@ const cli = defineCli({
             `[logs-server] loaded .env from ${envResult.path} (${envResult.keys} keys)\n`,
           );
         }
-        const { openDb, prune } = await import('./db.js');
-        const { dbPath, ensureParent } = await import('./paths.js');
+        const { prune } = await import('./db.js');
+        const { DbHandleCache } = await import('./db-cache.js');
+        const { dbPath, defaultDbPathForRepo } = await import('./paths.js');
         const { startServer } = await import('./server.js');
         const { loadConfig } = await import('./config.js');
+        const { walkLogDbs } = await import('./db-walk.js');
         const config = await loadConfig(process.cwd());
-        // CLI flags already fold env vars (via `env:` spec) — so flag > config > built-in.
         const effectivePort = (ctx.flags.port as number | undefined) ?? config.port;
         const effectiveHost = (ctx.flags.host as string | undefined) ?? config.host;
-        const configDbPath = config._dbPathResolved ?? config.dbPath;
-        const file = ensureParent(
-          dbPath((ctx.flags.db as string | undefined) ?? configDbPath),
-        );
-        const db = openDb(file);
-        const srv = startServer({
-          db,
-          port: effectivePort,
-          host: effectiveHost,
-          cors: config.cors,
-        });
+        const repoRoot = config._repoRoot ?? process.cwd();
+
+        // CLI --db / DIAG_DB / config.dbPath all pin a single file, in which
+        // case dispatch is meaningless and we fall back to single-DB mode.
+        // Without them, dispatch routes every envelope via the cache.
+        const pinned =
+          (ctx.flags.db as string | undefined) ||
+          process.env.DIAG_DB ||
+          config._dbPathResolved ||
+          config.dbPath;
+
+        const cache = new DbHandleCache();
+        cache.startIdleSweeper();
+        const defaultDbPath = pinned ? dbPath(pinned) : defaultDbPathForRepo(repoRoot);
+
+        const srv = pinned
+          ? startServer({
+              db: cache.getOrOpen(defaultDbPath),
+              port: effectivePort,
+              host: effectiveHost,
+              cors: config.cors,
+            })
+          : startServer({
+              cache,
+              defaultDbPath,
+              repoRoot,
+              port: effectivePort,
+              host: effectiveHost,
+              cors: config.cors,
+            });
         process.stdout.write(
-          `log-server listening on http://${srv.host}:${srv.port}  db=${file}\n`,
+          `log-server listening on http://${srv.host}:${srv.port}  ` +
+            `${pinned ? `db=${defaultDbPath}` : `logs=${defaultDbPath}/..`}\n`,
         );
         const days =
           (ctx.flags['prune-days'] as number | undefined) || config.pruneDays || 0;
         if (days > 0) {
-          setInterval(() => prune(db, days * 86_400_000), 3_600_000).unref();
+          // Walk all DBs each tick. With one pinned DB the walk yields just
+          // that file via the cache; with dispatch it sweeps every session DB
+          // currently materialized under .davstack/logs/.
+          setInterval(() => {
+            const files = pinned ? [defaultDbPath] : walkLogDbs(repoRoot);
+            for (const f of files) {
+              try {
+                prune(cache.getOrOpen(f), days * 86_400_000);
+              } catch {
+                // a DB file may be gone (rm'd by the user) — skip
+              }
+            }
+          }, 3_600_000).unref();
         }
         return new Promise<number>(() => {});
       },
@@ -237,7 +270,8 @@ const cli = defineCli({
       },
     },
     prune: {
-      description: 'Delete rows older than --days / --max-age-ms',
+      description:
+        'Delete rows older than --days / --max-age-ms. Walks every .davstack/logs/*.db unless --db pins one file.',
       flags: {
         db: dbFlag(),
         days: { type: 'number', default: 14 },
@@ -245,19 +279,42 @@ const cli = defineCli({
       },
       run: async (ctx) => {
         const { openDb, prune } = await import('./db.js');
-        const { dbPath } = await import('./paths.js');
+        const { dbPath, defaultDbPathForRepo } = await import('./paths.js');
         const { loadConfig } = await import('./config.js');
+        const { walkLogDbs } = await import('./db-walk.js');
         const config = await loadConfig(process.cwd());
-        const configDbPath = config._dbPathResolved ?? config.dbPath;
-        const db = openDb(
-          dbPath((ctx.flags.db as string | undefined) ?? configDbPath),
-        );
+        const repoRoot = config._repoRoot ?? process.cwd();
+
         const ageMs =
           (ctx.flags['max-age-ms'] as number | undefined) ??
           (ctx.flags.days as number) * 86_400_000;
-        process.stdout.write(
-          `pruned ${prune(db, ageMs)} rows (older than ${ageMs}ms)\n`,
-        );
+
+        const pinned =
+          (ctx.flags.db as string | undefined) ||
+          process.env.DIAG_DB ||
+          config._dbPathResolved ||
+          config.dbPath;
+
+        const files = pinned
+          ? [dbPath(pinned)]
+          : (() => {
+              const walked = walkLogDbs(repoRoot);
+              return walked.length > 0 ? walked : [defaultDbPathForRepo(repoRoot)];
+            })();
+
+        let total = 0;
+        for (const f of files) {
+          try {
+            const db = openDb(f);
+            const n = prune(db, ageMs);
+            db.close();
+            total += n;
+            process.stdout.write(`pruned ${n} rows from ${f}\n`);
+          } catch (err) {
+            process.stderr.write(`[logs-server] prune failed for ${f}: ${(err as Error).message}\n`);
+          }
+        }
+        process.stdout.write(`pruned ${total} rows total (older than ${ageMs}ms)\n`);
         return 0;
       },
     },

--- a/packages/logs-server/src/ingest.ts
+++ b/packages/logs-server/src/ingest.ts
@@ -2,22 +2,87 @@
 // every row (clock-skew safety — prune keys on this, not client ts), persist.
 // Wrapped so it can never throw to the HTTP layer: a sink that 500s or hangs
 // would block the app it is meant to observe (notes 03).
+//
+// Two entry points:
+//
+//   handleIngest(db, raw, now)
+//     Single-DB path — everything lands in `db`. Kept for tests and single-
+//     handle callers; equivalent to `dispatchIngest(raw, { dispatch: () => db })`.
+//
+//   dispatchIngest(raw, { cache, defaultDbPath, repoRoot, warn? }, now)
+//     Multi-DB path — each row's `davstack-logs.db` routing attribute is
+//     validated and resolved (see db-route.ts), then the row is inserted into
+//     the resolved file via the handle cache. Invalid / absent values fall
+//     back to defaultDbPath.
 
 import type { Database } from 'bun:sqlite';
+import type { DbHandleCache } from './db-cache.js';
 import { insertLogs, type LogRow } from './db.js';
-import { parseEnvelope } from './envelope.js';
+import { resolveRoutedDb } from './db-route.js';
+import { parseEnvelope, type ParsedLog } from './envelope.js';
 
-export function handleIngest(
-  db: Database,
-  rawBody: string,
-  now: number = Date.now(),
-): { accepted: number; skipped: number } {
+export type IngestResult = { accepted: number; skipped: number };
+
+export type DispatchContext = {
+  cache: DbHandleCache;
+  defaultDbPath: string;
+  repoRoot: string;
+  warn?: (msg: string) => void;
+};
+
+function stamp(rows: ParsedLog[], now: number): (LogRow & { routeDb?: string })[] {
+  return rows.map((r) => ({ ...r, recv_ts: now }));
+}
+
+export function handleIngest(db: Database, rawBody: string, now: number = Date.now()): IngestResult {
   try {
     const { rows, skipped } = parseEnvelope(rawBody);
-    const stamped: LogRow[] = rows.map((r) => ({ ...r, recv_ts: now }));
+    const stamped = stamp(rows, now);
     const accepted = insertLogs(db, stamped);
     return { accepted, skipped };
   } catch {
     return { accepted: 0, skipped: 0 };
   }
+}
+
+export function dispatchIngest(
+  rawBody: string,
+  ctx: DispatchContext,
+  now: number = Date.now(),
+): IngestResult {
+  try {
+    const { rows, skipped } = parseEnvelope(rawBody);
+    const stamped = stamp(rows, now);
+
+    // Group by resolved DB path. One bad row in a batch must not affect
+    // routing for the rest — each is classified independently.
+    const groups = new Map<string, LogRow[]>();
+    for (const r of stamped) {
+      const target = resolveTarget(r.routeDb, ctx);
+      const batch = groups.get(target) ?? [];
+      batch.push(stripInternal(r));
+      groups.set(target, batch);
+    }
+
+    let accepted = 0;
+    for (const [path, batch] of groups) {
+      const db = ctx.cache.getOrOpen(path);
+      accepted += insertLogs(db, batch);
+    }
+    return { accepted, skipped };
+  } catch {
+    return { accepted: 0, skipped: 0 };
+  }
+}
+
+function resolveTarget(routeDb: string | undefined, ctx: DispatchContext): string {
+  if (!routeDb) return ctx.defaultDbPath;
+  const r = resolveRoutedDb(routeDb, ctx.repoRoot, { warn: ctx.warn });
+  return r.ok ? r.path : ctx.defaultDbPath;
+}
+
+function stripInternal(row: LogRow & { routeDb?: string }): LogRow {
+  const { routeDb: _drop, ...rest } = row;
+  void _drop;
+  return rest;
 }

--- a/packages/logs-server/src/paths.ts
+++ b/packages/logs-server/src/paths.ts
@@ -1,10 +1,17 @@
-// Where the one shared DB lives. Mirrors cursor-jobs/paths.ts: a single
-// global data home, env-overridable. DIAG_DB pins an explicit file (used by
-// tests and `--db`); else DIAG_HOME or ~/.claude/diag/diag.sqlite.
+// Where the per-repo DB files live. As of 2.0.0 the default is
+// `<repoRoot>/.davstack/logs/default.db` — moved from the legacy single
+// `.davstack/logs.db` to make room for per-session siblings
+// (`.davstack/logs/<name>.db`). DIAG_DB still pins an explicit file (used by
+// tests and `--db`); DIAG_HOME / ~/.claude/diag is the global fallback when
+// no repo root is in play.
 
 import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+
+export const DEFAULT_DB_FILENAME = 'default.db';
+export const DEFAULT_DB_DIR = join('.davstack', 'logs');
+export const LEGACY_DB_RELATIVE = join('.davstack', 'logs.db');
 
 export function dataHome(): string {
   const e = process.env.DIAG_HOME;
@@ -17,6 +24,14 @@ export function dbPath(override?: string): string {
   const env = process.env.DIAG_DB;
   if (env && env.trim()) return resolve(env);
   return join(dataHome(), 'diag.sqlite');
+}
+
+export function defaultDbPathForRepo(repoRoot: string): string {
+  return join(repoRoot, DEFAULT_DB_DIR, DEFAULT_DB_FILENAME);
+}
+
+export function legacyDbPathForRepo(repoRoot: string): string {
+  return join(repoRoot, LEGACY_DB_RELATIVE);
 }
 
 export function ensureParent(file: string): string {

--- a/packages/logs-server/src/server.ts
+++ b/packages/logs-server/src/server.ts
@@ -4,6 +4,12 @@
 // a sink that 5xx's or hangs would induce SDK retry storms and block the very
 // app it observes (notes 03).
 //
+// Two construction modes:
+//   { db } ............... single-DB mode (tests / one-off scripts).
+//   { cache, defaultDbPath, repoRoot } ... multi-DB dispatch (the daemon
+//                                          surface; routes per the
+//                                          `davstack-logs.db` attribute).
+//
 // CORS: browser SDKs posting envelopes via DSN (Content-Type
 // application/x-sentry-envelope is non-simple) trigger a preflight. Default
 // policy is "*" — safe because the sink binds 127.0.0.1 only and never sets
@@ -12,7 +18,8 @@
 
 import type { Database } from 'bun:sqlite';
 import type { ServerConfig } from './config.js';
-import { handleIngest } from './ingest.js';
+import type { DbHandleCache } from './db-cache.js';
+import { handleIngest, dispatchIngest } from './ingest.js';
 import { decodeBody } from './decode.js';
 
 export function corsHeadersFor(
@@ -38,14 +45,30 @@ export function corsHeadersFor(
   return h;
 }
 
-export function startServer(opts: {
-  db: Database;
-  port?: number;
-  host?: string;
-  cors?: ServerConfig['cors'];
-}): { port: number; host: string; stop: () => void } {
+export type ServerOpts =
+  | {
+      db: Database;
+      cache?: undefined;
+      defaultDbPath?: undefined;
+      repoRoot?: undefined;
+      port?: number;
+      host?: string;
+      cors?: ServerConfig['cors'];
+    }
+  | {
+      cache: DbHandleCache;
+      defaultDbPath: string;
+      repoRoot: string;
+      db?: undefined;
+      port?: number;
+      host?: string;
+      cors?: ServerConfig['cors'];
+    };
+
+export function startServer(opts: ServerOpts): { port: number; host: string; stop: () => void } {
   const host = opts.host ?? process.env.DIAG_HOST ?? '127.0.0.1';
   const corsPolicy = opts.cors;
+  const ingest = makeIngest(opts);
   const server = Bun.serve({
     port: opts.port ?? (Number(process.env.DIAG_PORT) || 7077),
     hostname: host,
@@ -61,7 +84,7 @@ export function startServer(opts: {
         // Real SDKs gzip the envelope and set Content-Encoding; reading text()
         // on a gzip body silently produced zero rows. Decode by encoding.
         const bytes = new Uint8Array(await req.arrayBuffer());
-        handleIngest(opts.db, decodeBody(bytes, req.headers.get('content-encoding')));
+        ingest(decodeBody(bytes, req.headers.get('content-encoding')));
       } catch {
         // swallow — fire-and-forget; the app must never see a failure here
       }
@@ -74,4 +97,20 @@ export function startServer(opts: {
     },
   });
   return { port: server.port, host, stop: () => server.stop(true) };
+}
+
+function makeIngest(opts: ServerOpts): (raw: string) => void {
+  if ('db' in opts && opts.db) {
+    const db = opts.db;
+    return (raw) => {
+      handleIngest(db, raw);
+    };
+  }
+  if (!('cache' in opts) || !opts.cache || !opts.defaultDbPath || !opts.repoRoot) {
+    throw new Error('startServer: pass either { db } or { cache, defaultDbPath, repoRoot }');
+  }
+  const { cache, defaultDbPath, repoRoot } = opts;
+  return (raw) => {
+    dispatchIngest(raw, { cache, defaultDbPath, repoRoot });
+  };
 }

--- a/packages/playwright-server/CHANGELOG.md
+++ b/packages/playwright-server/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @davstack/playwright-server
 
+## 1.4.0
+
+### Minor Changes
+
+- Add `--db=<name>` flag to `playwright-server run`. When set, the daemon
+  seeds `window.__davstack_db` on the warm browser context (via
+  `addInitScript` + a one-shot `page.evaluate`) before evaluating the
+  spec. Consumers who stamp the `davstack-logs.db` Sentry log attribute
+  in their `beforeSendLog` (see `@davstack/logs-server`
+  `docs/transmitter-wiring.md`) get the run's logs routed to
+  `.davstack/logs/<name>.db` instead of the shared `default.db`.
+
+  No flag → no global → no attribute → unchanged behavior. Safe with
+  `@davstack/logs-server` 1.x consumers who don't read the attribute
+  (it's just a string set on `window`).
+
+  Daemon-side: `session.runOnce(file, { db })` accepts the option;
+  client-side: `runFile(file, opts, { db })` carries it through `/run`.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/playwright-server/__tests__/bun-only/client.test.ts
+++ b/packages/playwright-server/__tests__/bun-only/client.test.ts
@@ -5,7 +5,7 @@
 
 import { test, expect, afterEach } from 'bun:test';
 import type { Server } from 'bun';
-import { runFile, gotoUrl, refreshAuth, health, shutdown, type ClientOpts } from '../src/client.js';
+import { runFile, gotoUrl, refreshAuth, health, shutdown, type ClientOpts } from '../../src/client.js';
 
 const servers: Server[] = [];
 afterEach(() => {
@@ -89,6 +89,19 @@ test('shutdown swallows connection-refused errors', async () => {
   // Point at a port we know is closed; shutdown is best-effort.
   const r = await shutdown({ host: '127.0.0.1', port: 1 });
   expect(r.ok).toBe(true);
+});
+
+test('runFile passes the routing db through to /run body when provided', async () => {
+  const { base, recorded } = fakeServer(() => ok({ ok: true }));
+  await runFile('foo.spec.ts', clientOpts(base), { db: 'reorder-bug' });
+  expect(recorded[0].body).toEqual({ file: 'foo.spec.ts', db: 'reorder-bug' });
+});
+
+test('runFile omits db when not provided (no key, not null)', async () => {
+  const { base, recorded } = fakeServer(() => ok({ ok: true }));
+  await runFile('foo.spec.ts', clientOpts(base));
+  expect(recorded[0].body).toEqual({ file: 'foo.spec.ts' });
+  expect(Object.keys(recorded[0].body as object)).not.toContain('db');
 });
 
 test('runFile surfaces non-2xx response body', async () => {

--- a/packages/playwright-server/docs/usage.md
+++ b/packages/playwright-server/docs/usage.md
@@ -16,6 +16,18 @@ Two layers:
 | `health` | Liveness check. Returns `{ ok, pid, url }`. |
 | `shutdown` | Gracefully close the browser and exit the daemon. |
 
+### Routing this run's logs to a session DB
+
+Pass `--db=<name>` to seed `window.__davstack_db` before the page boots:
+
+```bash
+playwright-server run --db=reorder-bug e2e/reorder-flow.spec.ts
+```
+
+When the consumer's `Sentry.init` stamps `davstack-logs.db` in its `beforeSendLog` (3-line addition — see `@davstack/logs-server` `docs/transmitter-wiring.md`), every log this spec emits lands in `.davstack/logs/reorder-bug.db` instead of `default.db`. Omit the flag and logs route to `default.db` as usual.
+
+The daemon installs a context-level `addInitScript` so the value survives mid-spec navigations and re-seeds itself on every new document load. The value persists for subsequent runs until you pass a different `--db` or restart the daemon.
+
 `run <file>` shape (from `RunResult`):
 
 ```json

--- a/packages/playwright-server/package.json
+++ b/packages/playwright-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davstack/playwright-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "type": "module",
   "description": "Warm chromium daemon for fast e2e/UI iteration. Keeps a long-lived browser context hot so spec reruns hit the live window in 1-3s instead of paying cold-boot.",

--- a/packages/playwright-server/src/client.ts
+++ b/packages/playwright-server/src/client.ts
@@ -44,8 +44,23 @@ async function request<T>(
   return parsed as T;
 }
 
-export async function runFile(file: string, opts: ClientOpts): Promise<RunResponse> {
-  return request<RunResponse>('POST', '/run', opts, { file });
+export type RunFileOpts = {
+  /**
+   * Route this run's logs to `.davstack/logs/<db>.db`. Stamped onto every
+   * Sentry log envelope as the `davstack-logs.db` attribute via a context
+   * init script. See @davstack/logs-server docs/transmitter-wiring.md.
+   */
+  db?: string;
+};
+
+export async function runFile(
+  file: string,
+  opts: ClientOpts,
+  runOpts: RunFileOpts = {},
+): Promise<RunResponse> {
+  const body: Record<string, unknown> = { file };
+  if (runOpts.db) body.db = runOpts.db;
+  return request<RunResponse>('POST', '/run', opts, body);
 }
 
 export async function gotoUrl(url: string, opts: ClientOpts): Promise<{ url: string }> {

--- a/packages/playwright-server/src/http.ts
+++ b/packages/playwright-server/src/http.ts
@@ -62,7 +62,8 @@ export function startServer(opts: ServeOpts): Server {
       if (req.method === 'POST' && url.pathname === '/run') {
         const body = await readBody(req);
         if (!body.file) return send(res, 400, { ok: false, error: "missing 'file'" });
-        return send(res, 200, await session.runOnce(String(body.file)));
+        const db = typeof body.db === 'string' && body.db.length > 0 ? body.db : undefined;
+        return send(res, 200, await session.runOnce(String(body.file), { db }));
       }
       if (req.method === 'POST' && url.pathname === '/refresh-auth') {
         const r = await session.refreshAuth();

--- a/packages/playwright-server/src/index.ts
+++ b/packages/playwright-server/src/index.ts
@@ -83,10 +83,20 @@ const cli = defineCli({
     run: {
       description: 'Execute a spec file against the running daemon',
       positionals: [{ name: 'file', required: true, description: 'Spec path' }],
-      flags: clientFlags(),
+      flags: {
+        ...clientFlags(),
+        db: {
+          type: 'string' as const,
+          description:
+            "Route this run's logs to .davstack/logs/<db>.db via the davstack-logs.db attribute (logs-server 2.0+)",
+        },
+      },
       run: async (ctx) => {
         const { runFile } = await import('./client.js');
-        const result = await runFile(ctx.positionals[0], clientOpts(ctx.flags));
+        const db = ctx.flags.db as string | undefined;
+        const result = await runFile(ctx.positionals[0], clientOpts(ctx.flags), {
+          db: db && db.length > 0 ? db : undefined,
+        });
         console.log(JSON.stringify(result, null, 2));
         return result.ok ? 0 : 1;
       },

--- a/packages/playwright-server/src/session.ts
+++ b/packages/playwright-server/src/session.ts
@@ -265,7 +265,7 @@ export class PlaywrightSession {
     // window. Acceptable for a long-lived daemon during a debug session.
     await this.context.addInitScript(
       (value: string | null) => {
-        const w = window as unknown as { __davstack_db?: string };
+        const w = window as Window & { __davstack_db?: string };
         if (value === null) {
           delete w.__davstack_db;
         } else {
@@ -279,7 +279,7 @@ export class PlaywrightSession {
     // document can throw; the next navigation will re-seed via the script.
     try {
       await this.page.evaluate((value: string | null) => {
-        const w = window as unknown as { __davstack_db?: string };
+        const w = window as Window & { __davstack_db?: string };
         if (value === null) {
           delete w.__davstack_db;
         } else {

--- a/packages/playwright-server/src/session.ts
+++ b/packages/playwright-server/src/session.ts
@@ -223,7 +223,7 @@ export class PlaywrightSession {
 
   // ─── run ─────────────────────────────────────────────────────────────────
 
-  async runOnce(file: string): Promise<RunResult> {
+  async runOnce(file: string, opts: { db?: string } = {}): Promise<RunResult> {
     this.assertLive();
     // Serialise; concurrent runs would interleave on the single warm page.
     const release = this.runLock;
@@ -234,6 +234,14 @@ export class PlaywrightSession {
       const t0 = Date.now();
       const absFile = isAbsolute(file) ? file : resolve(this.cwd, file);
       const source = await readFile(absFile, 'utf8');
+
+      // Multi-DB log routing (logs-server 2.0+). Seed window.__davstack_db
+      // before navigation so the app's beforeSendLog reads it at init time.
+      // Two surfaces:
+      //   - page.evaluate sets it immediately on the current document
+      //   - context.addInitScript re-seeds on every subsequent navigation
+      // No-op if the spec didn't request a routing DB.
+      await this.applyDbRouting(opts.db);
 
       // Routing: the new registration-interception runner is the default.
       // It supports full TS, module-level imports/helpers, multiple
@@ -246,6 +254,40 @@ export class PlaywrightSession {
       return await this.runOnceModule(absFile, file, t0);
     } finally {
       releaseResolve();
+    }
+  }
+
+  private async applyDbRouting(db: string | undefined): Promise<void> {
+    if (!this.context || !this.page) return;
+    // Install a context-level init script every run; in steady-state usage
+    // these accumulate (Playwright has no removeInitScript), but the cost
+    // is a few hundred bytes per run and the LAST install wins on the
+    // window. Acceptable for a long-lived daemon during a debug session.
+    await this.context.addInitScript(
+      (value: string | null) => {
+        const w = window as unknown as { __davstack_db?: string };
+        if (value === null) {
+          delete w.__davstack_db;
+        } else {
+          w.__davstack_db = value;
+        }
+      },
+      db ?? null,
+    );
+    // Page.evaluate covers the case where the spec doesn't navigate (the
+    // init script wouldn't fire). Tolerate failure — pages without a real
+    // document can throw; the next navigation will re-seed via the script.
+    try {
+      await this.page.evaluate((value: string | null) => {
+        const w = window as unknown as { __davstack_db?: string };
+        if (value === null) {
+          delete w.__davstack_db;
+        } else {
+          w.__davstack_db = value;
+        }
+      }, db ?? null);
+    } catch {
+      // about:blank can't run scripts in some chromium builds — ignore
     }
   }
 


### PR DESCRIPTION
Multi-DB log routing. Transmitters stamp a `davstack-logs.db` attribute on each Sentry log envelope; the daemon validates, resolves to `.davstack/logs/<value>.db`, strips the attribute, and dispatches via a per-path Database handle cache. Un-tagged emissions land in the new `.davstack/logs/default.db`. The DB file IS the session boundary — cross-session noise disappears, eval runs can co-locate logs with their artifacts, and each session DB hosts its own SQL views with cleanup-via-`rm`.

Closes Issue 51 (session scoping). Builds on Issue 52 (logs_v view, shipped in 1.4.0).

## Packages shipped

| Package | From | To | Why |
|---|---|---|---|
| `@davstack/logs-server` | 1.4.0 | **2.0.0** | Default path move + dispatch layer |
| `@davstack/playwright-server` | 1.3.0 | **1.4.0** | New `--db=<name>` flag on `run` verb |

## Breaking change

Default DB path moves from `<repo>/.davstack/logs.db` to `<repo>/.davstack/logs/default.db`. One-command migration:

```bash
mv .davstack/logs.db .davstack/logs/default.db
```

`logs-server check` flags the legacy file at boot and prints the exact `mv` command. Anyone pinning a single file via `--db <path>`, `DIAG_DB`, or `dbPath` in config is unaffected (and the dispatch layer is bypassed, matching pre-2.0 single-DB behaviour).

## End-to-end pipeline

1. `playwright-server run --db=reorder-bug spec.ts` → daemon installs `window.__davstack_db = "reorder-bug"` on the warm context (`addInitScript` + `page.evaluate`).
2. App's existing `beforeSendLog` reads the global, stamps `davstack-logs.db` attribute on every log envelope (3-line consumer addition, see `docs/transmitter-wiring.md`).
3. logs-server 2.0 daemon validates, resolves to `.davstack/logs/reorder-bug.db`, strips the attribute, dispatches via DbHandleCache. First open auto-creates the `logs` table + correlation index + `logs_v` view.

## Validation

- **Unit**: 45 vitest + 21 bun-only tests across both packages, all green.
- **e2e smoke**: separate `davstack-e2e-test` repo installs the 2.0.0 tarball as a real npm dep and runs `smoke.sh` — 14 assertions over routing, fallback, traversal, subdirectories, multi-item batches, cross-call persistence, gzip path, warn-once, repo-escape containment, `logs_v` flattening, and no-log-dropped invariants. All pass against the real wire.
- **Build**: tsup clean on both packages, no new TS errors.

## Commit chain

1. `aa1beb3` — feat(logs-server): dispatch ingest by davstack-logs.db routing attribute (core: db-route, db-cache, envelope strip, dispatchIngest + tests)
2. `cd3ec85` — feat(logs-server)!: default path move + dispatch in serve (daemon wiring, prune walks all DBs, check legacy hint)
3. `b3d062e` — docs(logs-server): transmitter-wiring + session-views + 2.0.0 changelog
4. `e2e49b2` — feat(playwright-server): --db flag seeds window.__davstack_db on the warm context
5. `df765ef` — refactor(davstack): use Window & { __davstack_db?: string } intersection cast

## What's NOT in this PR

- **Cross-stack routing** (backend honoring the attribute). Today the user's stack is frontend-emission-only. If/when needed, ship as 2.x via an explicit `X-Davstack-Db` header or a daemon-side trace_id correlation cache — both were considered and deferred to avoid premature complexity.
- **`logs-server db list / drop` verbs.** `ls .davstack/logs/` + `rm` are fine for v1.
- **Sentry integration sub-package.** Consumer wiring is 3 lines — `docs/transmitter-wiring.md` shows them. No peer-dep / version-compat surface to maintain.

## Test plan

- [x] All existing tests still pass (envelope, ingest, check, query, view, acceptance, cors)
- [x] New unit coverage: db-route validation table, DbHandleCache lifecycle, dispatch fan-out, db-walk, check legacy hint
- [x] e2e smoke against the published tarball (14/14 green)
- [ ] Browser-side validation post-merge — set `window.__davstack_db` in devtools, verify rows land in the right session DB