### PR TITLE
feat(tui): controls-by-default + r refresh + alt+d repaint

### DIFF
--- a/packages/tui/src/components/ControlsHint.tsx
+++ b/packages/tui/src/components/ControlsHint.tsx
@@ -1,19 +1,17 @@
-// Collapsed-by-default keyboard hint row. Default shows `c for controls`;
-// toggled state inlines the full hint string. Toggle is owned by the
-// parent view via useInput so each view decides what `c` means.
+// Keyboard hint row. Always renders the controls string so the
+// available shortcuts are discoverable without a hidden binding.
 
 import React from "react"
 import { Box, Text } from "ink"
 
 export interface ControlsHintProps {
-  expanded: boolean
   controls: string
 }
 
-export function ControlsHint({ expanded, controls }: ControlsHintProps): React.ReactElement {
+export function ControlsHint({ controls }: ControlsHintProps): React.ReactElement {
   return (
     <Box marginTop={1}>
-      <Text dimColor>{expanded ? controls : "c for controls"}</Text>
+      <Text dimColor>{controls}</Text>
     </Box>
   )
 }

--- a/packages/tui/src/components/GlobalHotkeys.tsx
+++ b/packages/tui/src/components/GlobalHotkeys.tsx
@@ -1,8 +1,10 @@
 // Thin component that mounts ink's useInput and delegates to the
 // useHotkeys dispatcher. Keeping the ink-specific gating here lets the
-// hotkey logic stay testable on its own.
+// hotkey logic stay testable on its own. alt+d is intercepted here to
+// force a screen repaint via stdout — the dispatcher stays pure.
 
-import { useInput } from "ink"
+import { useCallback } from "react"
+import { useInput, useStdout } from "ink"
 
 import { useHotkeys } from "../hooks/useHotkeys.ts"
 
@@ -12,9 +14,21 @@ interface GlobalHotkeysProps {
 
 export function GlobalHotkeys({ onQuit }: GlobalHotkeysProps): null {
   const { handle } = useHotkeys(onQuit)
+  const { stdout } = useStdout()
   const rawModeSupported = process.stdin.isTTY === true
+
+  const repaint = useCallback(() => {
+    // Clear scrollback + screen and home the cursor. Ink will redraw on
+    // its next render tick.
+    stdout?.write("\x1b[2J\x1b[3J\x1b[H")
+  }, [stdout])
+
   useInput(
     (input, key) => {
+      if (key.meta && input === "d") {
+        repaint()
+        return
+      }
       handle(input, {
         ctrl: key.ctrl,
         escape: key.escape,
@@ -22,6 +36,7 @@ export function GlobalHotkeys({ onQuit }: GlobalHotkeysProps): null {
         rightArrow: key.rightArrow,
         tab: key.tab,
         shift: key.shift,
+        meta: key.meta,
       })
     },
     { isActive: rawModeSupported },

--- a/packages/tui/src/hooks/useAgentJobs.ts
+++ b/packages/tui/src/hooks/useAgentJobs.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { listJobs, type JobRecord } from "@davstack/open-agents/core/jobs"
 import { jobsDir } from "@davstack/open-agents/core/paths"
 
 export interface UseAgentJobsResult {
   jobs: JobRecord[]
+  refresh: () => void
 }
 
 function jobStableKey(j: JobRecord): string {
@@ -41,9 +42,17 @@ export function useAgentJobs(repoPath: string): UseAgentJobsResult {
     setJobs(next)
   }, [repoPath, tick])
 
+  const refresh = useCallback(() => {
+    // Force a re-read: invalidate the mtime + keys caches so the next
+    // listJobs always runs even if the directory mtime is stale.
+    lastMtimeRef.current = 0
+    lastKeysRef.current = ""
+    setTick((t) => t + 1)
+  }, [])
+
   const sorted = useMemo(() => sortAgentJobs(jobs), [jobs])
 
-  return { jobs: sorted }
+  return { jobs: sorted, refresh }
 }
 
 function sortAgentJobs(jobs: JobRecord[]): JobRecord[] {

--- a/packages/tui/src/hooks/useHotkeys.ts
+++ b/packages/tui/src/hooks/useHotkeys.ts
@@ -16,6 +16,7 @@ export interface KeyEvent {
   rightArrow?: boolean
   tab?: boolean
   shift?: boolean
+  meta?: boolean
 }
 
 export interface HotkeyHandlers {

--- a/packages/tui/src/views/AgentsList.tsx
+++ b/packages/tui/src/views/AgentsList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react"
+import React, { useMemo } from "react"
 import { Box, Text, useInput } from "ink"
 
 import type { JobRecord, JobStatus } from "@davstack/open-agents/core/jobs"
@@ -11,8 +11,7 @@ import { useNoColor, colorOrUndef } from "../hooks/useNoColor.ts"
 import { ControlsHint } from "../components/ControlsHint.tsx"
 
 const AGENTS_CONTROLS =
-  "↑/↓ j/k focus  enter drill in  esc back  g agents  q quit  " +
-  "● running  ✗ failed  ○ done"
+  "↑/↓ j/k focus  enter drill in  r refresh  esc back  g agents  q quit"
 
 const STATUS_LABEL: Record<JobStatus, string> = {
   running: "run",
@@ -30,15 +29,14 @@ const STATUS_COLOR: Record<JobStatus, string> = {
 
 export function AgentsList(): React.ReactElement {
   const repoPath = getRepoRootSafe()
-  const { jobs } = useAgentJobs(repoPath)
+  const { jobs, refresh } = useAgentJobs(repoPath)
   const { focusedIdx, setFocusedIdx, showAgent } = useView()
-  const [controlsOpen, setControlsOpen] = useState(false)
 
   const rawModeSupported = process.stdin.isTTY === true
   useInput(
     (input, key) => {
-      if (input === "c") {
-        setControlsOpen((v) => !v)
+      if (input === "r") {
+        refresh()
         return
       }
       if (jobs.length === 0) return
@@ -55,7 +53,7 @@ export function AgentsList(): React.ReactElement {
   )
 
   if (jobs.length === 0) {
-    return <AgentsEmptyState controlsOpen={controlsOpen} />
+    return <AgentsEmptyState />
   }
 
   const safeFocus = Math.min(focusedIdx, jobs.length - 1)
@@ -65,7 +63,7 @@ export function AgentsList(): React.ReactElement {
       {jobs.map((job, i) => (
         <AgentListRow key={job.id} job={job} focused={i === safeFocus} />
       ))}
-      <ControlsHint expanded={controlsOpen} controls={AGENTS_CONTROLS} />
+      <ControlsHint controls={AGENTS_CONTROLS} />
     </Box>
   )
 }
@@ -90,13 +88,13 @@ function AgentListRow({ job, focused }: { job: JobRecord; focused: boolean }): R
   )
 }
 
-function AgentsEmptyState({ controlsOpen }: { controlsOpen: boolean }): React.ReactElement {
+function AgentsEmptyState(): React.ReactElement {
   return (
     <Box flexDirection="column">
       <Text dimColor>
         No agents have run in this repo yet. Submit one with: explore &quot;&lt;prompt&gt;&quot;
       </Text>
-      <ControlsHint expanded={controlsOpen} controls={AGENTS_CONTROLS} />
+      <ControlsHint controls={AGENTS_CONTROLS} />
     </Box>
   )
 }

--- a/packages/tui/src/views/ServerList.test.tsx
+++ b/packages/tui/src/views/ServerList.test.tsx
@@ -53,7 +53,7 @@ afterEach(() => {
   active = null
 })
 
-test("controls hint is collapsed by default", () => {
+test("controls hint is visible by default", () => {
   const descriptors = [makeDescriptor("logs")]
   active = render(
     <ViewProvider>
@@ -67,8 +67,8 @@ test("controls hint is collapsed by default", () => {
     </ViewProvider>,
   )
   const frame = active.lastFrame() ?? ""
-  expect(frame).toContain("c for controls")
-  expect(frame).not.toContain("s start/stop")
+  expect(frame).toContain("s start/stop")
+  expect(frame).toContain("q quit")
 })
 
 test("renders a row per descriptor with the focus marker on idx 0", () => {

--- a/packages/tui/src/views/ServerList.tsx
+++ b/packages/tui/src/views/ServerList.tsx
@@ -2,7 +2,7 @@
 // hotkeys (`↑/↓`, `enter`, `s`). Global hotkeys (`1..9`, `esc`, `q`) live
 // in <GlobalHotkeys>.
 
-import React, { useState } from "react"
+import React from "react"
 import { Box, Text, useInput } from "ink"
 
 import type { DaemonStatus } from "../hooks/useDaemonProcess.ts"
@@ -13,8 +13,7 @@ import { useNoColor, colorOrUndef } from "../hooks/useNoColor.ts"
 import { ControlsHint } from "../components/ControlsHint.tsx"
 
 const DAEMONS_CONTROLS =
-  "↑/↓ focus  enter drill in  s start/stop  k takeover  1-9 jump  g agents  q quit  " +
-  "● running  ✗ crashed  ⚠ blocked"
+  "↑/↓ focus  enter drill in  s start/stop  k takeover  1-9 jump  g agents  q quit"
 
 const STATUS_GLYPH: Record<DaemonStatus, string> = {
   idle: "○",
@@ -41,7 +40,6 @@ const STATUS_COLOR: Record<DaemonStatus, string> = {
 export function ServerList(): React.ReactElement {
   const { rows } = useDaemons()
   const { focusedIdx, setFocusedIdx, showLog } = useView()
-  const [controlsOpen, setControlsOpen] = useState(false)
   // Hotkeys hook gives us the toggle; quit isn't called here so we pass
   // a noop — the global useInput owns the q routing.
   const { onToggleFocused } = useHotkeys(() => {})
@@ -49,10 +47,6 @@ export function ServerList(): React.ReactElement {
   const rawModeSupported = process.stdin.isTTY === true
   useInput(
     (input, key) => {
-      if (input === "c") {
-        setControlsOpen((v) => !v)
-        return
-      }
       if (rows.length === 0) return
       if (key.upArrow) {
         setFocusedIdx((focusedIdx - 1 + rows.length) % rows.length)
@@ -76,7 +70,7 @@ export function ServerList(): React.ReactElement {
       {rows.map((row, i) => (
         <DaemonListRow key={row.descriptor.key} row={row} focused={i === focusedIdx} />
       ))}
-      <ControlsHint expanded={controlsOpen} controls={DAEMONS_CONTROLS} />
+      <ControlsHint controls={DAEMONS_CONTROLS} />
     </Box>
   )
 }


### PR DESCRIPTION
## Summary
- Issue 45: controls visible by default, legend removed (the controls themselves document the keys)
- Issue 46: `r` in agents list re-scans for new/removed agents
- Issue 47: `alt+d` global repaint hotkey for the rare visual-corruption case

## Test plan
- [ ] `pnpm -F @davstack/tui test`
- [ ] Manual: spawn TUI, confirm controls visible without pressing `c`
- [ ] Manual: spawn an agent from another terminal, press `r`, confirm it shows
- [ ] Manual: force a visual artifact (e.g. resize mid-render), press `alt+d`, confirm clean repaint

Closes #45, #46, #47