### PR TITLE
fix(cli-utils): restartDaemon false-positive when prior daemon never dies (#60)

### DIFF
--- a/packages/cli-utils/CHANGELOG.md
+++ b/packages/cli-utils/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @davstack/cli-utils
 
+## 1.3.1
+
+### Patch Changes
+
+- Fix `restartDaemon` false-positive when the prior daemon doesn't actually
+  shut down (#60). The poll-for-health loop now snapshots the pre-shutdown
+  PID via `GET <healthPath>` and only accepts a 200 whose `pid` differs.
+  If the same PID keeps answering, the helper returns
+  `{ ok: false, error: "daemon shutdown did not take: pid N still answering …" }`
+  instead of silently reporting success against the surviving original.
+
+  Also hardens the spawn detach for bun-hosted daemons on Windows
+  (logs-server). `detached: true` + `stdio: 'ignore'` is unreliable when
+  `process.execPath` is `bun.exe` — the child stayed tethered to the
+  parent's console session and died once the CLI returned. The Windows-bun
+  path now wraps the spawn in `cmd /c start "" /B` to force a clean detach
+  via the shell's `start` verb. `child.pid` becomes the throwaway cmd.exe
+  on that path, so `restartDaemon` now surfaces the daemon-reported pid
+  from `/health` instead.
+
+  No behavior change for node-hosted daemons (playwright-server,
+  vitest-server) — they keep the original `detached: true` spawn.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/cli-utils/src/restart.ts
+++ b/packages/cli-utils/src/restart.ts
@@ -1,7 +1,15 @@
 // Shared daemon-restart helper used by playwright-server / vitest-server /
-// logs-server `refresh --hard`. Sequences: client-side shutdown → wait for
-// the listening socket to release → spawn a detached `<execPath> <entry>
-// serve …` → poll the daemon's health endpoint until it answers.
+// logs-server `refresh --hard`. Sequences: record the prior PID via health →
+// client-side shutdown → wait for the listening socket to release → spawn a
+// detached `<execPath> <entry> serve …` → poll the daemon's health endpoint
+// until a *different* PID answers.
+//
+// Health-PID verification is load-bearing: without it, the helper false-
+// positives when the prior daemon never died (#60). We record the pre-
+// shutdown pid via GET <healthPath>, then accept the post-spawn poll only
+// when health.pid differs from the prior pid. The new pid is what we surface
+// to the caller; spawn-returned `child.pid` is unreliable on Windows when
+// we go through `cmd /c start` to force-detach a bun-hosted daemon.
 //
 // `process.execPath` is reused as the runtime so node-hosted daemons stay
 // on node and bun-hosted ones (logs-server) stay on bun without needing
@@ -38,32 +46,87 @@ export type RestartResult = {
 export async function restartDaemon(opts: RestartOpts): Promise<RestartResult> {
   const t0 = Date.now();
   const target: RestartTarget = { host: opts.host, port: opts.port };
-  await bestEffortShutdown(target, opts.shutdownPath ?? '/shutdown');
+  const healthPath = opts.healthPath ?? '/health';
+  const shutdownPath = opts.shutdownPath ?? '/shutdown';
+
+  // Snapshot the current daemon PID before tearing it down. waitHealthy
+  // uses this to detect the "old daemon never died" failure mode — without
+  // it, the poll happily accepts a 200 from the surviving prior process.
+  const priorPid = await fetchHealthPid(target, healthPath);
+
+  await bestEffortShutdown(target, shutdownPath);
   // Wait for the old socket to release before re-binding. SO_REUSEADDR
   // semantics differ across platforms; on Windows in particular, immediate
   // re-bind can fail with EADDRINUSE.
   await waitPortClosed(target, 5000);
+
+  const child = await spawnDetached(opts.entry, opts.serveArgs);
+  const health = await waitHealthyFreshPid(
+    target,
+    healthPath,
+    opts.startupTimeoutMs ?? 30_000,
+    priorPid,
+  );
+  if (!health.ok) {
+    return {
+      ok: false,
+      pid: child.pid,
+      startupMs: Date.now() - t0,
+      error: health.error,
+    };
+  }
+  // Prefer the daemon-reported pid: under the `cmd /c start` Windows path,
+  // child.pid is the throwaway cmd.exe, not the daemon.
+  return { ok: true, pid: health.pid ?? child.pid, startupMs: Date.now() - t0 };
+}
+
+async function spawnDetached(
+  entry: string,
+  serveArgs: string[],
+): Promise<{ pid: number | undefined }> {
   const { spawn } = await import('node:child_process');
-  const child = spawn(process.execPath, [opts.entry, 'serve', ...opts.serveArgs], {
+  // `detached: true` + `stdio: 'ignore'` is enough for node-hosted daemons
+  // on every platform. For bun-hosted daemons (logs-server) on Windows the
+  // detach is unreliable — the child stays attached to the parent's console
+  // session and dies when the CLI returns (#60). Wrapping in `cmd /c start
+  // "" /B` forces a clean Windows detach via the shell's start verb. The
+  // returned child.pid is cmd.exe, which exits immediately; the daemon's
+  // real pid is read off /health by waitHealthyFreshPid.
+  if (process.platform === 'win32' && isBunExec(process.execPath)) {
+    const child = spawn(
+      'cmd.exe',
+      ['/c', 'start', '""', '/B', process.execPath, entry, 'serve', ...serveArgs],
+      { detached: true, stdio: 'ignore', windowsHide: true, windowsVerbatimArguments: false },
+    );
+    child.unref();
+    return { pid: child.pid };
+  }
+  const child = spawn(process.execPath, [entry, 'serve', ...serveArgs], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
   });
   child.unref();
-  const healthOk = await waitHealthy(
-    target,
-    opts.healthPath ?? '/health',
-    opts.startupTimeoutMs ?? 30_000,
-  );
-  if (!healthOk) {
-    return {
-      ok: false,
-      pid: child.pid,
-      startupMs: Date.now() - t0,
-      error: 'daemon did not become healthy within timeout',
-    };
+  return { pid: child.pid };
+}
+
+function isBunExec(execPath: string): boolean {
+  const lower = execPath.toLowerCase();
+  return lower.endsWith('\\bun.exe') || lower.endsWith('/bun.exe') || lower.endsWith('bun');
+}
+
+async function fetchHealthPid(
+  target: RestartTarget,
+  path: string,
+): Promise<number | undefined> {
+  try {
+    const res = await fetch(`http://${target.host}:${target.port}${path}`);
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { pid?: unknown };
+    return typeof body.pid === 'number' ? body.pid : undefined;
+  } catch {
+    return undefined;
   }
-  return { ok: true, pid: child.pid, startupMs: Date.now() - t0 };
 }
 
 async function bestEffortShutdown(target: RestartTarget, path: string): Promise<void> {
@@ -91,20 +154,40 @@ async function waitPortClosed(target: RestartTarget, deadlineMs: number): Promis
   }
 }
 
-async function waitHealthy(
+async function waitHealthyFreshPid(
   target: RestartTarget,
   path: string,
   deadlineMs: number,
-): Promise<boolean> {
+  priorPid: number | undefined,
+): Promise<{ ok: true; pid: number | undefined } | { ok: false; error: string }> {
   const deadline = Date.now() + deadlineMs;
+  let lastSeenPid: number | undefined;
   while (Date.now() < deadline) {
     try {
       const res = await fetch(`http://${target.host}:${target.port}${path}`);
-      if (res.ok) return true;
+      if (res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { pid?: unknown };
+        const pid = typeof body.pid === 'number' ? body.pid : undefined;
+        lastSeenPid = pid;
+        // Stale-pid guard: if the same process that was running before the
+        // shutdown is still answering, the shutdown didn't take and the
+        // poll would silently false-positive. Keep polling.
+        if (priorPid !== undefined && pid === priorPid) {
+          await new Promise((r) => setTimeout(r, 200));
+          continue;
+        }
+        return { ok: true, pid };
+      }
     } catch {
       // socket not up yet
     }
     await new Promise((r) => setTimeout(r, 200));
   }
-  return false;
+  if (lastSeenPid !== undefined && lastSeenPid === priorPid) {
+    return {
+      ok: false,
+      error: `daemon shutdown did not take: pid ${priorPid} still answering /${path.replace(/^\//, '')}`,
+    };
+  }
+  return { ok: false, error: 'daemon did not become healthy within timeout' };
 }


### PR DESCRIPTION
## Summary

Closes #60.

`restartDaemon` was reporting `{ok: true}` even when the prior daemon never actually died — the post-spawn `waitHealthy` happily accepted a 200 from the surviving original. Adds two fixes:

- **PID-mismatch guard.** Snapshot the prior pid via `GET <healthPath>` before shutdown; only accept a 200 whose `pid` differs. If the same pid keeps answering, return `ok:false` with `error: "daemon shutdown did not take: pid N still answering /__health"`.
- **Windows-bun spawn hardening.** When `process.execPath` is `bun.exe` on win32, wrap the spawn in `cmd /c start "" /B`. `detached: true` + `stdio: 'ignore'` is the documented Node recipe but is unreliable when the runtime is bun on Windows — the child stayed tethered to the parent's console session and died once the CLI returned. The `start` verb forces a clean detach. `child.pid` becomes the throwaway cmd.exe, so the surfaced `pid` is now the daemon-reported one from `/health`. No change for node-hosted daemons (playwright-server, vitest-server).

## Test plan

- [x] Cold case (no daemon): `logs-server refresh --hard` spawns + survives; pid in response matches `/__health` pid
- [x] Warm case (daemon running): pid swaps cleanly, new daemon survives
- [x] Simulated #60 (a daemon that 200s on `/__shutdown` but doesn't exit): helper now returns `{ ok: false, error: "daemon shutdown did not take: pid 63148 still answering /__health" }` and exit 1, instead of a silent ok:true
- [ ] TUI integration (`davstack start` watcher reattach) — not retested; behavior unchanged since `--hard` still loses the daemon PID by design

Tested locally against a `davstack-e2e-test` project consuming a fresh `pnpm pack` tarball.