### PR TITLE
feat: standardise daemon CLI naming (check→doctor) + agent lifecycle guidance

### DIFF
--- a/.changeset/daemon-cli-doctor-rename.md
+++ b/.changeset/daemon-cli-doctor-rename.md
@@ -1,0 +1,12 @@
+---
+"@davstack/logs-server": minor
+"@davstack/vitest-server": minor
+"@davstack/playwright-server": minor
+---
+
+Rename the per-server install-validation verb `check` → `doctor` (matching
+`brew doctor` / `flutter doctor`), freeing `check` for the `davstack check`
+orchestrator only. Behaviour, flags (`--json`, `--cwd`, …) and output are
+unchanged. The old `check` verb is retained as a deprecated alias that
+delegates to `doctor`, so existing scripts keep working for now — migrate to
+`<server> doctor`. `health` (liveness ping) is unchanged.

--- a/.changeset/davstack-check-terse-success.md
+++ b/.changeset/davstack-check-terse-success.md
@@ -1,0 +1,10 @@
+---
+"@davstack/tui": minor
+---
+
+`davstack check` is now terse on success: when every configured daemon is up
+it prints a single line (`✓ All davstack daemons running and ready.`) with no
+header or per-daemon table, keeping an agent's context clean. The full table
+plus the start hint still print when something is down. Exit codes are
+unchanged (0 ok / 1 some down / 2 no config). The start hint now reads
+`davstack start` instead of `pnpm dlx @davstack/tui start`.

--- a/.changeset/init-logs-skill-sqlite.md
+++ b/.changeset/init-logs-skill-sqlite.md
@@ -1,0 +1,10 @@
+---
+"@davstack/init": patch
+---
+
+Update the bundled `logs-server` skill: drop the removed `logs-server query`
+verbs (trace/run/errors/filter, gone since logs-server 2.1.0) and document the
+current read path — reading the store directly with sqlite3 against
+`.davstack/logs/<db>`, mirroring the canonical skill. Also adds the shared
+lifecycle rule (ask the user to run `davstack start`; never run `serve`
+yourself).

--- a/.changeset/init-logs-skill-sqlite.md
+++ b/.changeset/init-logs-skill-sqlite.md
@@ -1,10 +1,18 @@
 ---
-"@davstack/init": patch
+"@davstack/init": minor
 ---
 
-Update the bundled `logs-server` skill: drop the removed `logs-server query`
-verbs (trace/run/errors/filter, gone since logs-server 2.1.0) and document the
-current read path — reading the store directly with sqlite3 against
-`.davstack/logs/<db>`, mirroring the canonical skill. Also adds the shared
+Install the davstack TUI (`@davstack/tui`) globally on every init run, so the
+`davstack` bin (`davstack start` / `davstack check`) resolves from any repo —
+freshly-init'd repos now have the orchestrator the bundled skills expect. It
+ships unconditionally alongside the other global tools, independent of which
+daemons were selected (it's the orchestrator, not a selectable daemon).
+`printNextSteps` now points at `davstack start` (in a separate terminal) +
+`davstack check` instead of the per-server `<server> check` lines.
+
+Also update the bundled `logs-server` skill: drop the removed `logs-server
+query` verbs (trace/run/errors/filter, gone since logs-server 2.1.0) and
+document the current read path — reading the store directly with sqlite3
+against `.davstack/logs/<db>`, mirroring the canonical skill. Adds the shared
 lifecycle rule (ask the user to run `davstack start`; never run `serve`
 yourself).

--- a/.changeset/init-logs-skill-sqlite.md
+++ b/.changeset/init-logs-skill-sqlite.md
@@ -10,9 +10,11 @@ daemons were selected (it's the orchestrator, not a selectable daemon).
 `printNextSteps` now points at `davstack start` (in a separate terminal) +
 `davstack check` instead of the per-server `<server> check` lines.
 
-Also update the bundled `logs-server` skill: drop the removed `logs-server
-query` verbs (trace/run/errors/filter, gone since logs-server 2.1.0) and
-document the current read path — reading the store directly with sqlite3
-against `.davstack/logs/<db>`, mirroring the canonical skill. Adds the shared
-lifecycle rule (ask the user to run `davstack start`; never run `serve`
-yourself).
+Also bring the bundled `logs-server`, `vitest-server`, and `playwright-server`
+skills in line with the canonical skills: drop the removed `logs-server query`
+verbs (trace/run/errors/filter, gone since logs-server 2.1.0) in favour of
+reading the store directly with sqlite3 against `.davstack/logs/<db>`; remove
+the `serve &` / per-server `check` recipes; and add the shared lifecycle rule
+(ask the user to run `davstack start` in a separate terminal; never run
+`serve` yourself). The playwright skill also drops the obsolete "only the first
+top-level `test()`" limitation.

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -54,13 +54,20 @@ async function pickTools(opts: CliOptions): Promise<Tool[]> {
 // findRepoRoot(cwd), so global install doesn't lose per-repo settings.)
 const GLOBAL_TOOLS: Tool[] = ["open-agents"]
 
+// Always-global packages installed on every init run, independent of which
+// daemons were selected. `@davstack/tui` provides the `davstack` bin
+// (`davstack start` / `davstack check`) — the orchestrator that spawns and
+// owns the configured daemons together. It's not a selectable daemon, so it
+// lives outside the Tool union / ALL_TOOLS and ships globally so `davstack`
+// resolves from any repo (matching the GLOBAL_TOOLS rationale above).
+const ALWAYS_GLOBAL_PACKAGES = ["@davstack/tui"]
+
 function installCommand(
   manager: PackageManager,
-  tools: Tool[],
+  packages: string[],
   workspaceRoot: boolean,
   global: boolean,
 ): { cmd: string; args: string[] } {
-  const packages = tools.map((t) => `@davstack/${t}`)
   if (global) {
     switch (manager) {
       case "pnpm":
@@ -93,11 +100,11 @@ function installCommand(
 function runInstallGroup(
   root: string,
   manager: PackageManager,
-  tools: Tool[],
+  packages: string[],
   global: boolean,
 ): void {
   const workspaceRoot = manager === "pnpm" && isPnpmWorkspaceRoot(root)
-  const { cmd, args } = installCommand(manager, tools, workspaceRoot, global)
+  const { cmd, args } = installCommand(manager, packages, workspaceRoot, global)
   console.log(`\n> ${cmd} ${args.join(" ")}`)
   const result = spawnSync(cmd, args, {
     cwd: root,
@@ -110,18 +117,27 @@ function runInstallGroup(
 }
 
 function runInstall(root: string, manager: PackageManager, tools: Tool[]): void {
-  const local = tools.filter((t) => !GLOBAL_TOOLS.includes(t))
-  const global = tools.filter((t) => GLOBAL_TOOLS.includes(t))
+  const local = tools.filter((t) => !GLOBAL_TOOLS.includes(t)).map((t) => `@davstack/${t}`)
+  const global = tools.filter((t) => GLOBAL_TOOLS.includes(t)).map((t) => `@davstack/${t}`)
   if (local.length > 0) runInstallGroup(root, manager, local, false)
-  if (global.length > 0) runInstallGroup(root, manager, global, true)
+  // The davstack TUI ships globally on every run, regardless of selection.
+  if (global.length > 0) runInstallGroup(root, manager, [...global, ...ALWAYS_GLOBAL_PACKAGES], true)
+  else runInstallGroup(root, manager, ALWAYS_GLOBAL_PACKAGES, true)
 }
 
 function printNextSteps(tools: Tool[]): void {
+  const daemons = tools.filter((t) => t !== "open-agents")
   console.log("")
   console.log("Done. Next:")
-  if (tools.includes("logs-server")) console.log("  npx logs-server check")
-  if (tools.includes("vitest-server")) console.log("  npx vitest-server check")
-  if (tools.includes("playwright-server")) console.log("  npx playwright-server check")
+  if (daemons.length > 0) {
+    console.log("  davstack start    # in a SEPARATE terminal — launches all configured daemons")
+    console.log("  davstack check    # confirm the daemons are up")
+    console.log("")
+    console.log("  `davstack` is installed globally (the davstack TUI). Run `davstack start`")
+    console.log("  in its own long-running terminal; Claude can't run it for you. Once it's")
+    console.log("  up, `davstack check` reports each daemon's health.")
+    console.log("")
+  }
   if (tools.includes("open-agents")) {
     console.log("  explore check                 # verifies cursor-agent install")
     console.log("  explore   submit '<goal>…</goal> <scope>…</scope>'")

--- a/packages/init/src/skills/logs-server.md
+++ b/packages/init/src/skills/logs-server.md
@@ -1,45 +1,92 @@
 ---
 name: logs-server
 description: >-
-  Query a local Sentry-shaped log sink (per-repo `.davstack/logs.db`) for
-  cross-service timelines, error windows, or `trace_id` / `run_id` slices.
-  Use when the user references a failed request, agent run, or test
-  invocation and you need the actual log timeline rather than guessing.
-  Also use when planting hypothesis-driven probes during a `diagnose`
-  loop. Skip for tail-following live stdout (use the dev server directly)
-  or for prod logs (this is local-only).
+  Query a local Sentry-shaped log sink (per-session SQLite under
+  `.davstack/logs/<name>.db`) for cross-service timelines, error windows,
+  or `trace_id` / `run_id` slices. Use when the user references a failed
+  request, agent run, or test invocation and you need the actual log
+  timeline rather than guessing. Also use when planting hypothesis-driven
+  probes during a `diagnose` loop. Skip for tail-following live stdout
+  (use the dev server directly) or for prod logs (this is local-only).
 ---
 
-The query CLI reads `.davstack/logs.db` directly — it works even if the
-ingest daemon isn't running. You only need `serve` running for the app to
-write new envelopes.
+First run `davstack check` to confirm the daemon is running.
 
-    logs-server check                                  # verifies sink reachable + DB has rows
-    logs-server query trace --trace <id>               # cross-service assembly for one trace
-    logs-server query run   --run <id>                 # timeline for one invocation
-    logs-server query errors --context 20              # errors + N surrounding rows
-    logs-server query filter --grep "<msg>" --limit 50 # generic level/grep/run/trace cut
+> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
 
-Default output is one-row-per-line, agent-readable. Add `--json` to pipe
-into `jq`. Indexed columns: `project, run_id, trace_id, level, ts` —
-filter on those first, then `--grep` for substring within the result set.
+## The read path is sqlite3
+
+`logs-server` has no `query` CLI verb (removed in 2.1.0). You read the store directly with sqlite3 against `.davstack/logs/<db>` — works even if the ingest daemon isn't running. You only need `serve` running for the app to *write* new envelopes.
+
+### Standard incantation
+
+```bash
+sqlite3 -header -column .davstack/logs/<db> "<SQL>"
+```
+
+`-header` prints column names. `-column` aligns the output as a table. Without these you get pipe-separated values with no labels — fine for piping, terrible for reading.
+
+### Picking the DB
+
+```
+.davstack/logs/
+  default.db          ← un-tagged emissions
+  reorder-bug.db      ← runs started with --db=reorder-bug
+  hotfix-7c.db
+```
+
+`default.db` is the catch-all. Named siblings appear when a transmitter stamps a `davstack-logs.db` attribute (or `playwright-server --db=<name>`). The file IS the session boundary.
+
+## Schema
+
+```
+logs(id, ts, recv_ts, project, service, run_id, trace_id, span_id,
+     level, severity_number, logger, msg, data, attrs, tag)
+```
+
+Indexed on `(project, run_id, trace_id, level, ts)` — filter on those first.
+
+- **`msg`** — log body, ANSI prefix stripped.
+- **`data`** — raw Sentry log record JSON, verbatim. Includes OTel-typed `attributes`.
+- **`attrs`** — flat `{key: value}` JSON of `data.attributes`, OTel `{value, type}` wrapper stripped. Reach in with `json_extract(attrs, '$.<key>')`.
+- **`tag`** — promoted from `diag.tag` (nullable).
 
 ## Investigation pattern
 
 1. Get a `trace_id` or `run_id` from the user (the chat message, the
    error stamp, or the URL hash that holds `__diagRunId`).
-2. `query trace` / `query run` to see the full timeline.
-3. If too noisy, narrow with `query errors` or `query filter --level error`.
-4. For fat data payloads, use `--json | jq '.[] | .data.<field>'` rather
-   than dumping the whole row.
+
+2. Timeline for one run / trace:
+
+   ```bash
+   sqlite3 -header -column .davstack/logs/default.db "
+     SELECT ts, level, msg
+     FROM logs
+     WHERE run_id = '<id>'
+     ORDER BY ts;
+   "
+   ```
+
+3. Narrow to errors:
+
+   ```bash
+   sqlite3 -header -column .davstack/logs/default.db "
+     SELECT ts, level, msg
+     FROM logs
+     WHERE level = 'error'
+     ORDER BY ts DESC LIMIT 20;
+   "
+   ```
+
+4. For fat data payloads, project specific fields with `json_extract(data, '$.<path>')` rather than dumping the whole `data` blob.
 
 For hypothesis-driven probe-then-slice debugging, see `writing-logs.md`.
 
-If a query returns empty or hits the wrong DB, the failure is usually in the sink config or transmitter, not your search — `check` reports the resolved path and recent row count; see `setup.md` for transmitter wiring.
+If a query returns empty or hits the wrong DB, the failure is usually in the sink config or transmitter — `davstack check` reports the resolved path and recent row count; see `setup.md` for transmitter wiring.
 
 ## Reference
 
 - [`README.md`](../../packages/logs-server/README.md) — overview, install, why
 - [`docs/setup.md`](../../packages/logs-server/docs/setup.md) — config file, transmitter setup, auto-instrumentation
 - [`docs/writing-logs.md`](../../packages/logs-server/docs/writing-logs.md) — queryable shape, hypothesis-driven probes
-- [`docs/reading-logs.md`](../../packages/logs-server/docs/reading-logs.md) — every query verb + raw sqlite recipes
+- [`docs/reading-logs.md`](../../packages/logs-server/docs/reading-logs.md) — schema details + raw sqlite recipes

--- a/packages/init/src/skills/playwright-server.md
+++ b/packages/init/src/skills/playwright-server.md
@@ -10,18 +10,22 @@ description: >-
   configuring playwright itself.
 ---
 
-Boot once per session, then drive cheaply.
+Boot once per session, then drive cheaply. First run `davstack check` to
+confirm the daemon is running.
 
-    playwright-server check                  # daemon liveness + chromium + auth
-    playwright-server serve &                # boot if check fails (~5-15s)
+> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
+
+Once the daemon is up, drive it with the per-daemon CLI:
+
     playwright-server run <file>             # warm rerun (~1-3s); JSON RunResult
     playwright-server goto <url>             # navigate live page (returns { url })
     playwright-server refresh-auth           # mint a fresh session, reseed context
 
-Exit `0` = pass, `1` = fail. Spec extractor runs **only the first top-level
-`test('...', async ({ page, ... }) => { ... })`** — no `describe`, no
-hooks, no custom fixtures. Wrap codegen output in that exact shape;
-otherwise see [`usage.md`](../../packages/playwright-server/docs/usage.md).
+Exit `0` = pass, `1` = fail. Specs are loaded as real ES modules — full
+TypeScript, multiple `test()` blocks, `test.describe`, `beforeEach` /
+`afterEach`, and `test.use({ storageState })` all work. Custom
+`test.extend(...)` fixtures are the one current gap. See
+[`usage.md`](../../packages/playwright-server/docs/usage.md) for details.
 
 If results look wrong (blank window, cold-boot crash, `no test() block found`, 401 redirects, daemon exit 1), the failure is usually in the daemon, not your code — check `troubleshooting.md` before iterating, or fall back to `playwright test`.
 

--- a/packages/init/src/skills/vitest-server.md
+++ b/packages/init/src/skills/vitest-server.md
@@ -9,19 +9,20 @@ description: >-
   itself (daemon caches go stale).
 ---
 
-Boot once per session, then rerun cheaply.
+Boot once per session, then rerun cheaply. First run `davstack check` to
+confirm the daemon is running.
 
-    vitest-server check                # verifies daemon liveness + config
-    vitest-server serve &              # boot if check fails (heavy ~50s first time)
+> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
+
+Once the daemon is up, drive it with the per-daemon CLI:
+
     vitest-server run <file>           # warm rerun (~3-15s); JSON RunResult on stdout
 
 Exit `0` = pass, `1` = fail. The full `RunResult` shape (per-test entries,
 error stacks, run-level errors) is on stdout — pipe to `jq` if you only
 want failing tests.
 
-If `check` reports the daemon isn't running, `serve` it once and wait for
-the listening line before invoking `run`. Don't restart `serve` between
-runs — the warm pool is the entire point.
+Don't restart the daemon between runs — the warm pool is the entire point.
 
 If results look wrong (`(0 test)`, suite errors, post-config-edit weirdness), the failure is usually in the daemon, not your code — check `troubleshooting.md` before iterating, or fall back to `vitest run`.
 

--- a/packages/logs-server/docs/setup.md
+++ b/packages/logs-server/docs/setup.md
@@ -181,7 +181,7 @@ Lock down with an allowlist or `false` if you disagree.
 ## 7. Sanity check
 
 ```bash
-logs-server check
+logs-server doctor
 ```
 
 Reports node version, resolved config path, resolved `dbPath` (with total + recent row counts), and daemon liveness against the configured `host:port`. Exit code is 0 unless the install itself is broken (e.g. node < 20) — a not-running daemon or zero recent rows are reported as info, not failure, so agents can disambiguate "broken install" from "needs `serve`". Add `--json` for agent-parseable output.

--- a/packages/logs-server/src/index.ts
+++ b/packages/logs-server/src/index.ts
@@ -6,7 +6,8 @@
 //   serve         boot the ingest endpoint
 //   refresh       evict cached DB handles + re-read config; keep PID
 //   health        liveness check
-//   check         validate local install (node, config, db rows, daemon liveness)
+//   doctor        validate local install (node, config, db rows, daemon liveness)
+//                 (formerly `check`; `check` retained as a deprecated alias)
 //
 // Reading the log store: use sqlite3 directly against `.davstack/logs/<db>`.
 // The flat `attrs` column is populated at insert time so probe attributes
@@ -16,11 +17,32 @@
 // Retention is file-based: each session writes its own `.davstack/logs/<name>.db`,
 // so cleanup is `mv` into an archive dir. See docs/reading-logs.md#sessions.
 
-import { defineCli } from '@davstack/cli-utils';
+import { defineCli, type CommandSpec } from '@davstack/cli-utils';
 
 function dbFlag() {
   return { type: 'string' as const, description: 'Path to the log-server sqlite db', env: 'DIAG_DB' };
 }
+
+const doctorSpec: CommandSpec = {
+  description: 'Validate local install (node, config, db rows, daemon liveness)',
+  flags: {
+    db: dbFlag(),
+    port: { type: 'number', env: 'DIAG_PORT' },
+    host: { type: 'string', env: 'DIAG_HOST' },
+    cwd: { type: 'string', default: process.cwd() },
+    json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
+  },
+  run: async (ctx) => {
+    const { runCheck } = await import('./check.js');
+    return runCheck({
+      cwd: ctx.flags.cwd as string,
+      host: ctx.flags.host as string | undefined,
+      port: ctx.flags.port as number | undefined,
+      db: ctx.flags.db as string | undefined,
+      json: ctx.flags.json as boolean,
+    });
+  },
+};
 
 const cli = defineCli({
   name: 'logs-server',
@@ -175,25 +197,10 @@ const cli = defineCli({
         return result.ok ? 0 : 1;
       },
     },
+    doctor: doctorSpec,
     check: {
-      description: 'Validate local install (node, config, db rows, daemon liveness)',
-      flags: {
-        db: dbFlag(),
-        port: { type: 'number', env: 'DIAG_PORT' },
-        host: { type: 'string', env: 'DIAG_HOST' },
-        cwd: { type: 'string', default: process.cwd() },
-        json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
-      },
-      run: async (ctx) => {
-        const { runCheck } = await import('./check.js');
-        return runCheck({
-          cwd: ctx.flags.cwd as string,
-          host: ctx.flags.host as string | undefined,
-          port: ctx.flags.port as number | undefined,
-          db: ctx.flags.db as string | undefined,
-          json: ctx.flags.json as boolean,
-        });
-      },
+      ...doctorSpec,
+      description: "Validate local install (deprecated alias for 'doctor')",
     },
   },
 });

--- a/packages/playwright-server/src/index.ts
+++ b/packages/playwright-server/src/index.ts
@@ -10,6 +10,7 @@
 //   refresh-auth   mint a fresh session and reseed the live context
 //   health         daemon liveness check
 //   shutdown       gracefully stop the daemon
+//   doctor         validate local install (formerly `check`; `check` kept as a deprecated alias)
 //
 // All non-serve verbs are CLI clients — they fetch() the running daemon and
 // don't import chromium, so they're cold-start cheap (~50 ms).
@@ -73,6 +74,24 @@ const serveSpec: CommandSpec = {
     process.on('SIGINT', () => sig('SIGINT'));
     process.on('SIGTERM', () => sig('SIGTERM'));
     return new Promise<number>(() => {});
+  },
+};
+
+const doctorSpec: CommandSpec = {
+  description: 'Validate local install (node, peer dep, chromium, config, daemon liveness)',
+  flags: {
+    ...clientFlags(),
+    cwd: { type: 'string', default: process.cwd() },
+    json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
+  },
+  run: async (ctx) => {
+    const { runCheck } = await import('./check.js');
+    return runCheck({
+      cwd: ctx.flags.cwd as string,
+      host: ctx.flags.host as string,
+      port: ctx.flags.port as number,
+      json: ctx.flags.json as boolean,
+    });
   },
 };
 
@@ -180,22 +199,10 @@ const cli = defineCli({
         return 0;
       },
     },
+    doctor: doctorSpec,
     check: {
-      description: 'Validate local install (node, peer dep, chromium, config, daemon liveness)',
-      flags: {
-        ...clientFlags(),
-        cwd: { type: 'string', default: process.cwd() },
-        json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
-      },
-      run: async (ctx) => {
-        const { runCheck } = await import('./check.js');
-        return runCheck({
-          cwd: ctx.flags.cwd as string,
-          host: ctx.flags.host as string,
-          port: ctx.flags.port as number,
-          json: ctx.flags.json as boolean,
-        });
-      },
+      ...doctorSpec,
+      description: "Validate local install (deprecated alias for 'doctor')",
     },
   },
 });

--- a/packages/tui/src/commands/check.test.ts
+++ b/packages/tui/src/commands/check.test.ts
@@ -114,7 +114,7 @@ describe("formatResult", () => {
     expect(out).toContain("/repo")
   })
 
-  test("all-running output omits the start hint", () => {
+  test("all-running output is a terse single line with no table or hint", () => {
     const out = formatResult(
       {
         kind: "checked",
@@ -126,11 +126,15 @@ describe("formatResult", () => {
       },
       false,
     )
-    expect(out).toContain("All configured daemons running.")
-    expect(out).not.toContain("pnpm dlx @davstack/tui start")
+    expect(out).toBe("✓ All davstack daemons running and ready.")
+    expect(out).not.toContain("davstack start")
+    // no header and no per-daemon table on success
+    expect(out).not.toContain("cwd:")
+    expect(out).not.toContain("not running")
+    expect(out.split("\n")).toHaveLength(1)
   })
 
-  test("some-missing output includes the start hint", () => {
+  test("some-missing output includes the table and start hint", () => {
     const out = formatResult(
       {
         kind: "checked",
@@ -143,7 +147,8 @@ describe("formatResult", () => {
       false,
     )
     expect(out).toContain("1 daemon(s) not running.")
-    expect(out).toContain("pnpm dlx @davstack/tui start")
+    expect(out).toContain("davstack start")
+    expect(out).toContain("davstack check (cwd: /repo)")
   })
 
   test("color=true emits ANSI escapes; color=false does not", () => {

--- a/packages/tui/src/commands/check.ts
+++ b/packages/tui/src/commands/check.ts
@@ -67,7 +67,7 @@ function red(s: string, useColor: boolean): string {
 const START_HINT = [
   "To start the missing daemons, run this in a separate terminal:",
   "",
-  "  pnpm dlx @davstack/tui start",
+  "  davstack start",
   "",
   "The TUI supervises every configured daemon together; closing it",
   "cleans them up. Re-run `davstack check` to confirm.",
@@ -78,6 +78,12 @@ export function formatResult(result: CheckResult, useColor: boolean): string {
 
   if (result.kind === "no-config") {
     return [header, "", "No davstack configs found. Run: pnpm dlx @davstack/init"].join("\n")
+  }
+
+  // Terse on success: a single line, no header, no per-daemon table — keeps
+  // the agent's context clean. Detail + remediation only when something is down.
+  if (result.rows.every((r) => r.running)) {
+    return `${green("✓", useColor)} All davstack daemons running and ready.`
   }
 
   const labelWidth = Math.max(...result.rows.map((r) => r.descriptor.label.length), 1)
@@ -94,14 +100,9 @@ export function formatResult(result: CheckResult, useColor: boolean): string {
     if (!row.running) missing += 1
   }
   lines.push("")
-
-  if (missing === 0) {
-    lines.push("All configured daemons running.")
-  } else {
-    lines.push(`${missing} daemon(s) not running.`)
-    lines.push("")
-    lines.push(START_HINT)
-  }
+  lines.push(`${missing} daemon(s) not running.`)
+  lines.push("")
+  lines.push(START_HINT)
 
   return lines.join("\n")
 }

--- a/packages/vitest-server/src/index.ts
+++ b/packages/vitest-server/src/index.ts
@@ -7,6 +7,7 @@
 //   refresh          flush vitest's transform cache + vite-node module cache; re-read config; keep PID
 //   health           liveness check
 //   shutdown         stop the daemon
+//   doctor           validate local install (formerly `check`; `check` kept as a deprecated alias)
 //
 // Runtime: recommended `node --experimental-transform-types ./index.ts
 // serve` (Node 24+). Bun works on Linux/macOS but fails on Windows
@@ -87,6 +88,24 @@ const serveSpec: CommandSpec = {
     process.on('SIGINT', () => sig('SIGINT'));
     process.on('SIGTERM', () => sig('SIGTERM'));
     return new Promise<number>(() => {});
+  },
+};
+
+const doctorSpec: CommandSpec = {
+  description: 'Validate local install (node, peer dep, config, daemon liveness)',
+  flags: {
+    ...clientFlags(),
+    cwd: { type: 'string', default: process.cwd() },
+    json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
+  },
+  run: async (ctx) => {
+    const { runCheck } = await import('./check.js');
+    return runCheck({
+      cwd: ctx.flags.cwd as string,
+      host: ctx.flags.host as string,
+      port: ctx.flags.port as number,
+      json: ctx.flags.json as boolean,
+    });
   },
 };
 
@@ -179,22 +198,10 @@ const cli = defineCli({
         return 0;
       },
     },
+    doctor: doctorSpec,
     check: {
-      description: 'Validate local install (node, peer dep, config, daemon liveness)',
-      flags: {
-        ...clientFlags(),
-        cwd: { type: 'string', default: process.cwd() },
-        json: { type: 'boolean', default: false, description: 'JSON output for agent parsing' },
-      },
-      run: async (ctx) => {
-        const { runCheck } = await import('./check.js');
-        return runCheck({
-          cwd: ctx.flags.cwd as string,
-          host: ctx.flags.host as string,
-          port: ctx.flags.port as number,
-          json: ctx.flags.json as boolean,
-        });
-      },
+      ...doctorSpec,
+      description: "Validate local install (deprecated alias for 'doctor')",
     },
   },
 });

--- a/skills/logs-server/SKILL.md
+++ b/skills/logs-server/SKILL.md
@@ -10,7 +10,9 @@ description: >-
   (use the dev server directly) or for prod logs (this is local-only).
 ---
 
-First run `davstack check` to confirm the daemon is running. If it isn't, the command prints the start instructions.
+First run `davstack check` to confirm the daemon is running.
+
+> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
 
 ## The read path is sqlite3
 

--- a/skills/playwright-server/SKILL.md
+++ b/skills/playwright-server/SKILL.md
@@ -11,12 +11,12 @@ description: >-
 ---
 
 Boot once per session, then drive cheaply. First run `davstack check` to
-confirm the daemon is running — if it isn't, the command prints the start
-instructions. Fall back to the per-daemon CLI below to run
-playwright-server in isolation.
+confirm the daemon is running.
 
-    playwright-server check                  # daemon liveness + chromium + auth
-    playwright-server serve &                # boot if check fails (~5-15s)
+> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
+
+Once the daemon is up, drive it with the per-daemon CLI:
+
     playwright-server run <file>             # warm rerun (~1-3s); JSON RunResult
     playwright-server goto <url>             # navigate live page (returns { url })
     playwright-server refresh-auth           # mint a fresh session, reseed context

--- a/skills/vitest-server/SKILL.md
+++ b/skills/vitest-server/SKILL.md
@@ -10,21 +10,19 @@ description: >-
 ---
 
 Boot once per session, then rerun cheaply. First run `davstack check` to
-confirm the daemon is running — if it isn't, the command prints the start
-instructions. Fall back to the per-daemon CLI below to run vitest-server
-in isolation.
+confirm the daemon is running.
 
-    vitest-server check                # verifies daemon liveness + config
-    vitest-server serve &              # boot if check fails (heavy ~50s first time)
+> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
+
+Once the daemon is up, drive it with the per-daemon CLI:
+
     vitest-server run <file>           # warm rerun (~3-15s); JSON RunResult on stdout
 
 Exit `0` = pass, `1` = fail. The full `RunResult` shape (per-test entries,
 error stacks, run-level errors) is on stdout — pipe to `jq` if you only
 want failing tests.
 
-If `check` reports the daemon isn't running, `serve` it once and wait for
-the listening line before invoking `run`. Don't restart `serve` between
-runs — the warm pool is the entire point.
+Don't restart the daemon between runs — the warm pool is the entire point.
 
 If results look wrong (`(0 test)`, suite errors, post-config-edit weirdness), the failure is usually in the daemon, not your code — check `troubleshooting.md` before iterating, or fall back to `vitest run`.
 


### PR DESCRIPTION
@
Implements the five immediate action items from
`notes/server-cli-consolidation/01-naming-lifecycle-and-docs.md` (§5).

## Changes

1. **Skills — agents never boot daemons.** Removed the `serve &` recipes and
   per-server readiness `check` lines from the agent-facing command blocks in
   `skills/{playwright,vitest,logs}-server/SKILL.md`. Added one shared rule
   (identical wording across all three): if `davstack check` reports a daemon
   down, ask the user to run `davstack start` in a separate terminal; never run
   `serve` yourself. Skills now point at `davstack check` for readiness.

2. **`davstack check` terse on success.** On all-healthy it returns a single
   line (`✓ All davstack daemons running and ready.`) with no header/table.
   Failure branch (table + hint) and no-config branch unchanged. Exit codes
   unchanged (0/1/2). Tests updated.

3. **Rename per-server `check` → `doctor`.** In the three daemon `defineCli`
   specs (`logs-server`, `vitest-server`, `playwright-server`). Behaviour and
   flags identical. `health` untouched. **Breaking rename** for the three
   daemon CLIs — `check` is retained as a deprecated alias that delegates to
   `doctor` (so existing scripts keep working). `davstack check` and
   open-agents `check` are unchanged. Updated `logs-server/docs/setup.md`.

4. **Standardise the start string.** `START_HINT` in `check.ts` now reads
   `davstack start` (was `pnpm dlx @davstack/tui start`), matching the skills.

5. **Stop the init-fork bleeding.** `packages/init/src/skills/logs-server.md`
   no longer documents the removed `logs-server query` verbs (gone since 2.1.0);
   replaced with the current sqlite3 read path mirroring the canonical skill.
   Full skill generation remains deferred.

## Changesets
- `@davstack/{logs,vitest,playwright}-server` minor — `check`→`doctor` rename.
- `@davstack/tui` minor — terse check.
- `@davstack/init` patch — bundled logs skill fix.

## Verification
- Built `cli-utils`, `open-agents`, and the three daemons (tsup ESM + DTS) — all pass.
- `vitest run` for projects `tui`, `cli-utils`, `logs-server`, `vitest-server`,
  `playwright-server` — all green (163 tui+cli-utils, 95 daemon).
- Confirmed `vitest-server` / `playwright-server` built CLIs show `doctor`,
  deprecated `check`, and `health` in `--help`. (`logs-server` is a Bun target
  so its built bundle does not run under Node; its `doctor` spec is verified via
  the passing `__tests__/check.test.ts` unit suite and the shared parser.)

Source-of-truth notes: `notes/server-cli-consolidation/01-naming-lifecycle-and-docs.md`
@