### PR TITLE
refactor: lean CLI-reference list + lifecycle hint in `davstack check`

### DIFF
--- a/.changeset/lean-cli-block-and-lifecycle-hint.md
+++ b/.changeset/lean-cli-block-and-lifecycle-hint.md
@@ -1,0 +1,14 @@
+---
+"@davstack/tui": patch
+"@davstack/init": patch
+---
+
+Trim the generated skill CLI-reference to a lean bullet list (command +
+required positionals + one-line description, with a pointer to
+`<server> <command> --help` for flags) instead of an exhaustive table —
+the per-flag detail was noise. Deprecated aliases are dropped from the list.
+
+Move the daemon-lifecycle guidance ("ask the user to run `davstack start`
+in a separate terminal; don't run `serve` yourself") out of every daemon
+skill and into the `davstack check` failure output, since that advice only
+matters at the moment a daemon is reported down.

--- a/packages/init/src/skills/logs-server.md
+++ b/packages/init/src/skills/logs-server.md
@@ -16,8 +16,6 @@ description: >-
 
 First run `davstack check` to confirm the daemon is running.
 
-> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
-
 ## The read path is sqlite3
 
 `logs-server` has no `query` CLI verb (removed in 2.1.0). You read the store directly with sqlite3 against `.davstack/logs/<db>` — works even if the ingest daemon isn't running. You only need `serve` running for the app to *write* new envelopes.
@@ -118,12 +116,11 @@ For hypothesis-driven probe-then-slice debugging, see `writing-logs.md`.
 
 `logs-server` — Local Sentry-shaped log ingest. Read the store with sqlite3 against .davstack/logs/<db> (see docs/reading-logs.md).
 
-| Command | Description | Positionals & flags |
-| --- | --- | --- |
-| `logs-server serve` | Boot the log-ingest HTTP endpoint | `--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db<br>`--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`) |
-| `logs-server refresh` | Evict the daemon's cached DB handles and re-read config without restarting (keeps the daemon PID alive). Pass --hard for a full shutdown + detached re-serve (loses PID; needed for port/host/cors changes). | `--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`)<br>`--hard <boolean>` (default: `false`) — Full shutdown + detached re-serve (loses daemon PID).<br>`--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db |
-| `logs-server health` | Daemon liveness check | `--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`) |
-| `logs-server doctor` | Validate local install (node, config, db rows, daemon liveness) | `--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db<br>`--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
-| `logs-server check` | Validate local install (deprecated alias for 'doctor') | `--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db<br>`--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
+- `logs-server serve` — Boot the log-ingest HTTP endpoint
+- `logs-server refresh` — Evict the daemon's cached DB handles and re-read config without restarting (keeps the daemon PID alive). Pass --hard for a full shutdown + detached re-serve (loses PID; needed for port/host/cors changes).
+- `logs-server health` — Daemon liveness check
+- `logs-server doctor` — Validate local install (node, config, db rows, daemon liveness)
+
+Run `logs-server <command> --help` for the full flags and options of any command.
 
 <!-- END cli-reference -->

--- a/packages/init/src/skills/playwright-server.md
+++ b/packages/init/src/skills/playwright-server.md
@@ -17,8 +17,6 @@ description: >-
 Boot once per session, then drive cheaply. First run `davstack check` to
 confirm the daemon is running.
 
-> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
-
 Once the daemon is up, drive it with the per-daemon CLI:
 
     playwright-server run <file>             # warm rerun (~1-3s); JSON RunResult
@@ -47,16 +45,15 @@ If results look wrong (blank window, cold-boot crash, `no test() block found`, 4
 
 `playwright-server` — Long-lived warm-browser daemon + CLI client for fast e2e iteration.
 
-| Command | Description | Positionals & flags |
-| --- | --- | --- |
-| `playwright-server serve` | Boot the long-lived warm-browser daemon | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`) — HTTP listen port<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) — HTTP listen host<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root (where playwright-server.config.ts lives) |
-| `playwright-server run` | Execute a spec file against the running daemon | `<file>` — Spec path<br>`--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--db <string>` — Route this run's logs to .davstack/logs/<db>.db via the davstack-logs.db attribute (logs-server 2.0+) |
-| `playwright-server goto` | Navigate the live page to a URL | `<url>`<br>`--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server refresh` | Flush spec-module ESM cache and re-read config without restarting (keeps the warm browser + daemon PID alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient (port/host change, wedged browser). | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--hard <boolean>` (default: `false`) — Full shutdown + detached re-serve (loses daemon PID).<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root passed to the re-spawned serve (--hard only). |
-| `playwright-server refresh-auth` | Mint a fresh session and reseed the live context | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server health` | Daemon liveness check | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server shutdown` | Stop the running daemon | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server doctor` | Validate local install (node, peer dep, chromium, config, daemon liveness) | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
-| `playwright-server check` | Validate local install (deprecated alias for 'doctor') | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
+- `playwright-server serve` — Boot the long-lived warm-browser daemon
+- `playwright-server run <file>` — Execute a spec file against the running daemon
+- `playwright-server goto <url>` — Navigate the live page to a URL
+- `playwright-server refresh` — Flush spec-module ESM cache and re-read config without restarting (keeps the warm browser + daemon PID alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient (port/host change, wedged browser).
+- `playwright-server refresh-auth` — Mint a fresh session and reseed the live context
+- `playwright-server health` — Daemon liveness check
+- `playwright-server shutdown` — Stop the running daemon
+- `playwright-server doctor` — Validate local install (node, peer dep, chromium, config, daemon liveness)
+
+Run `playwright-server <command> --help` for the full flags and options of any command.
 
 <!-- END cli-reference -->

--- a/packages/init/src/skills/vitest-server.md
+++ b/packages/init/src/skills/vitest-server.md
@@ -16,8 +16,6 @@ description: >-
 Boot once per session, then rerun cheaply. First run `davstack check` to
 confirm the daemon is running.
 
-> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
-
 Once the daemon is up, drive it with the per-daemon CLI:
 
     vitest-server run <file>           # warm rerun (~3-15s); JSON RunResult on stdout
@@ -43,14 +41,13 @@ If results look wrong (`(0 test)`, suite errors, post-config-edit weirdness), th
 
 `vitest-server` — Long-lived Vitest daemon + CLI client for fast story/unit reruns.
 
-| Command | Description | Positionals & flags |
-| --- | --- | --- |
-| `vitest-server serve` | Boot the long-lived Vitest daemon | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root<br>`--project <string>` — Vitest project filter (overrides vitest-server.config.ts)<br>`--prime <string>` (env: `VITEST_SERVER_PRIME_FILE`) — File to prime the storybook plugin on boot (overrides config) |
-| `vitest-server run` | Rerun a file against the running daemon | `<file>` — Spec/story path<br>`--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--grep <string>` — Vitest testNamePattern filter |
-| `vitest-server refresh` | Flush vitest transform cache + vite-node module cache and re-read config without restarting (keeps the warm vitest instance alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient. | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--hard <boolean>` (default: `false`) — Full shutdown + detached re-serve (loses daemon PID).<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root passed to the re-spawned serve (--hard only).<br>`--project <string>` — Vitest project filter, passed to the re-spawned serve (--hard only).<br>`--prime <string>` (env: `VITEST_SERVER_PRIME_FILE`) — Prime file passed to the re-spawned serve (--hard only). |
-| `vitest-server health` | Daemon liveness check | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`) |
-| `vitest-server shutdown` | Stop the running daemon | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`) |
-| `vitest-server doctor` | Validate local install (node, peer dep, config, daemon liveness) | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
-| `vitest-server check` | Validate local install (deprecated alias for 'doctor') | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
+- `vitest-server serve` — Boot the long-lived Vitest daemon
+- `vitest-server run <file>` — Rerun a file against the running daemon
+- `vitest-server refresh` — Flush vitest transform cache + vite-node module cache and re-read config without restarting (keeps the warm vitest instance alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient.
+- `vitest-server health` — Daemon liveness check
+- `vitest-server shutdown` — Stop the running daemon
+- `vitest-server doctor` — Validate local install (node, peer dep, config, daemon liveness)
+
+Run `vitest-server <command> --help` for the full flags and options of any command.
 
 <!-- END cli-reference -->

--- a/packages/tui/src/commands/check.ts
+++ b/packages/tui/src/commands/check.ts
@@ -65,12 +65,15 @@ function red(s: string, useColor: boolean): string {
 }
 
 const START_HINT = [
-  "To start the missing daemons, run this in a separate terminal:",
+  "Ask the user to run this in a SEPARATE, long-lived terminal — Claude can't",
+  "run it (a daemon in an agent's shell dies with the session), and a user-owned",
+  "terminal is reused across sessions, which makes the whole session faster.",
+  "Don't run `serve` yourself.",
   "",
   "  davstack start",
   "",
-  "The TUI supervises every configured daemon together; closing it",
-  "cleans them up. Re-run `davstack check` to confirm.",
+  "The TUI supervises every configured daemon together; closing it cleans them",
+  "up. Re-run `davstack check` to confirm.",
 ].join("\n")
 
 export function formatResult(result: CheckResult, useColor: boolean): string {

--- a/scripts/gen-skill-cli-reference.ts
+++ b/scripts/gen-skill-cli-reference.ts
@@ -13,7 +13,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
-import type { CliSpec, CommandSpec, FlagSpec, Positional } from '@davstack/cli-utils';
+import type { CliSpec, CommandSpec } from '@davstack/cli-utils';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
@@ -32,96 +32,68 @@ const targets: Target[] = ['logs-server', 'vitest-server', 'playwright-server'].
 );
 
 // ─── rendering ────────────────────────────────────────────────────────────
+//
+// We deliberately emit a LEAN list, not an exhaustive table: command +
+// required positionals + the one-line description, plus a single pointer to
+// `--help` for the full flag set. Dumping every optional flag here is just
+// noise — an agent can run `<server> <command> --help` when it actually needs
+// a flag. Optional positionals, flags, and deprecated aliases are omitted.
 
-function mdEscape(s: string): string {
-  // Escape pipe so descriptions don't break the markdown table.
-  return s.replace(/\|/g, '\\|');
-}
-
-// Some flags default to `process.cwd()` (resolved at spec-eval time). That's
-// a machine-specific absolute path and would make the generated doc both
-// non-deterministic and non-idempotent across checkouts. Normalize it to a
-// stable placeholder so committed output is reproducible everywhere.
-const CWD = process.cwd();
-
-function renderDefault(value: unknown): string {
-  if (typeof value === 'string' && value === CWD) return '`(current directory)`';
-  return `\`${JSON.stringify(value)}\``;
-}
-
-function renderFlag(name: string, def: FlagSpec): string {
-  // Mirror cli-help.ts formatFlag semantics: name, type, then meta
-  // (default / env / required), then description.
-  const meta: string[] = [];
-  if (def.default !== undefined) meta.push(`default: ${renderDefault(def.default)}`);
-  if (def.env) meta.push(`env: \`${def.env}\``);
-  if (def.required) meta.push('required');
-  const metaStr = meta.length ? ` (${meta.join(', ')})` : '';
-  const desc = def.description ? ` — ${def.description}` : '';
-  return `\`--${name} <${def.type}>\`${metaStr}${desc}`;
-}
-
-function renderPositional(p: Positional): string {
-  const tag = p.required ? `\`<${p.name}>\`` : `\`[${p.name}]\``;
-  const desc = p.description ? ` — ${p.description}` : '';
-  return `${tag}${desc}`;
+// Only required positionals are surfaced (e.g. `run <file>`).
+function requiredPositionals(node: CommandSpec): string {
+  return (node.positionals ?? [])
+    .filter((p) => p.required)
+    .map((p) => `<${p.name}>`)
+    .join(' ');
 }
 
 // Walk the command tree (like parseArgs/formatHelp descend through
-// `commands`), emitting one table row per command that has a run handler or
-// is a leaf. Path segments are joined with spaces.
-function collectRows(
+// `commands`), emitting one entry per runnable leaf command. Commands whose
+// description marks them deprecated are skipped — this is a curated surface,
+// not a 1:1 mirror of every alias.
+function collectCommands(
   node: CommandSpec,
   path: string[],
-  rows: { command: string; description: string; args: string }[],
+  out: { command: string; description: string }[],
 ): void {
   const children = node.commands ? Object.entries(node.commands) : [];
-
-  // Emit a row for this node if it is runnable or a leaf (no children).
   const isRoot = path.length === 0;
-  if (!isRoot && (node.run || children.length === 0)) {
-    rows.push({
-      command: path.join(' '),
+  const deprecated = /deprecated/i.test(node.description ?? '');
+
+  if (!isRoot && (node.run || children.length === 0) && !deprecated) {
+    const pos = requiredPositionals(node);
+    out.push({
+      command: pos ? `${path.join(' ')} ${pos}` : path.join(' '),
       description: node.description ?? '',
-      args: renderArgs(node),
     });
   }
 
   for (const [name, child] of children) {
-    collectRows(child, [...path, name], rows);
+    collectCommands(child, [...path, name], out);
   }
 }
 
-function renderArgs(node: CommandSpec): string {
-  const parts: string[] = [];
-  for (const p of node.positionals ?? []) parts.push(renderPositional(p));
-  for (const [name, def] of Object.entries(node.flags ?? {})) {
-    parts.push(renderFlag(name, def));
-  }
-  if (parts.length === 0) return '';
-  return parts.map(mdEscape).join('<br>');
-}
-
-function renderTable(spec: CliSpec): string {
-  const rows: { command: string; description: string; args: string }[] = [];
-  collectRows(spec, [], rows);
+function renderList(spec: CliSpec): string {
+  const cmds: { command: string; description: string }[] = [];
+  collectCommands(spec, [], cmds);
 
   const lines: string[] = [];
   lines.push(`\`${spec.name}\` — ${spec.description ?? ''}`.trimEnd());
   lines.push('');
-  lines.push('| Command | Description | Positionals & flags |');
-  lines.push('| --- | --- | --- |');
-  for (const r of rows) {
-    const cmd = `\`${spec.name} ${r.command}\``;
-    lines.push(`| ${cmd} | ${mdEscape(r.description)} | ${r.args || '—'} |`);
+  for (const c of cmds) {
+    lines.push(`- \`${spec.name} ${c.command}\` — ${c.description}`);
   }
+  lines.push('');
+  lines.push(
+    `Run \`${spec.name} <command> --help\` for the full flags and options of any command.`,
+  );
   return lines.join('\n');
 }
 
 function renderBlock(spec: CliSpec): string {
   // The marker comments bracket a fully generated region. Stable formatting
   // (no timestamps) keeps regeneration idempotent.
-  return [BEGIN, '', renderTable(spec), '', END].join('\n');
+  return [BEGIN, '', renderList(spec), '', END].join('\n');
 }
 
 // ─── injection ──────────────────────────────────────────────────────────

--- a/skills/logs-server/SKILL.md
+++ b/skills/logs-server/SKILL.md
@@ -12,8 +12,6 @@ description: >-
 
 First run `davstack check` to confirm the daemon is running.
 
-> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
-
 ## The read path is sqlite3
 
 `logs-server` has no `query` CLI verb (removed in 2.1.0). You read the store directly with sqlite3 against `.davstack/logs/<db>` — works even if the ingest daemon isn't running. You only need `serve` running for the app to *write* new envelopes.
@@ -114,12 +112,11 @@ For hypothesis-driven probe-then-slice debugging, see `writing-logs.md`.
 
 `logs-server` — Local Sentry-shaped log ingest. Read the store with sqlite3 against .davstack/logs/<db> (see docs/reading-logs.md).
 
-| Command | Description | Positionals & flags |
-| --- | --- | --- |
-| `logs-server serve` | Boot the log-ingest HTTP endpoint | `--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db<br>`--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`) |
-| `logs-server refresh` | Evict the daemon's cached DB handles and re-read config without restarting (keeps the daemon PID alive). Pass --hard for a full shutdown + detached re-serve (loses PID; needed for port/host/cors changes). | `--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`)<br>`--hard <boolean>` (default: `false`) — Full shutdown + detached re-serve (loses daemon PID).<br>`--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db |
-| `logs-server health` | Daemon liveness check | `--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`) |
-| `logs-server doctor` | Validate local install (node, config, db rows, daemon liveness) | `--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db<br>`--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
-| `logs-server check` | Validate local install (deprecated alias for 'doctor') | `--db <string>` (env: `DIAG_DB`) — Path to the log-server sqlite db<br>`--port <number>` (env: `DIAG_PORT`)<br>`--host <string>` (env: `DIAG_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
+- `logs-server serve` — Boot the log-ingest HTTP endpoint
+- `logs-server refresh` — Evict the daemon's cached DB handles and re-read config without restarting (keeps the daemon PID alive). Pass --hard for a full shutdown + detached re-serve (loses PID; needed for port/host/cors changes).
+- `logs-server health` — Daemon liveness check
+- `logs-server doctor` — Validate local install (node, config, db rows, daemon liveness)
+
+Run `logs-server <command> --help` for the full flags and options of any command.
 
 <!-- END cli-reference -->

--- a/skills/playwright-server/SKILL.md
+++ b/skills/playwright-server/SKILL.md
@@ -13,8 +13,6 @@ description: >-
 Boot once per session, then drive cheaply. First run `davstack check` to
 confirm the daemon is running.
 
-> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
-
 Once the daemon is up, drive it with the per-daemon CLI:
 
     playwright-server run <file>             # warm rerun (~1-3s); JSON RunResult
@@ -43,16 +41,15 @@ If results look wrong (blank window, cold-boot crash, `no test() block found`, 4
 
 `playwright-server` — Long-lived warm-browser daemon + CLI client for fast e2e iteration.
 
-| Command | Description | Positionals & flags |
-| --- | --- | --- |
-| `playwright-server serve` | Boot the long-lived warm-browser daemon | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`) — HTTP listen port<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) — HTTP listen host<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root (where playwright-server.config.ts lives) |
-| `playwright-server run` | Execute a spec file against the running daemon | `<file>` — Spec path<br>`--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--db <string>` — Route this run's logs to .davstack/logs/<db>.db via the davstack-logs.db attribute (logs-server 2.0+) |
-| `playwright-server goto` | Navigate the live page to a URL | `<url>`<br>`--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server refresh` | Flush spec-module ESM cache and re-read config without restarting (keeps the warm browser + daemon PID alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient (port/host change, wedged browser). | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--hard <boolean>` (default: `false`) — Full shutdown + detached re-serve (loses daemon PID).<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root passed to the re-spawned serve (--hard only). |
-| `playwright-server refresh-auth` | Mint a fresh session and reseed the live context | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server health` | Daemon liveness check | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server shutdown` | Stop the running daemon | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`) |
-| `playwright-server doctor` | Validate local install (node, peer dep, chromium, config, daemon liveness) | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
-| `playwright-server check` | Validate local install (deprecated alias for 'doctor') | `--port <number>` (default: `5180`, env: `PLAYWRIGHT_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `PLAYWRIGHT_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
+- `playwright-server serve` — Boot the long-lived warm-browser daemon
+- `playwright-server run <file>` — Execute a spec file against the running daemon
+- `playwright-server goto <url>` — Navigate the live page to a URL
+- `playwright-server refresh` — Flush spec-module ESM cache and re-read config without restarting (keeps the warm browser + daemon PID alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient (port/host change, wedged browser).
+- `playwright-server refresh-auth` — Mint a fresh session and reseed the live context
+- `playwright-server health` — Daemon liveness check
+- `playwright-server shutdown` — Stop the running daemon
+- `playwright-server doctor` — Validate local install (node, peer dep, chromium, config, daemon liveness)
+
+Run `playwright-server <command> --help` for the full flags and options of any command.
 
 <!-- END cli-reference -->

--- a/skills/vitest-server/SKILL.md
+++ b/skills/vitest-server/SKILL.md
@@ -12,8 +12,6 @@ description: >-
 Boot once per session, then rerun cheaply. First run `davstack check` to
 confirm the daemon is running.
 
-> If `davstack check` reports a daemon down, ask the user to run `davstack start` in a **separate terminal** — this makes the whole session faster. Claude can't run it for you; it must live in its own terminal. Do not run `serve` yourself.
-
 Once the daemon is up, drive it with the per-daemon CLI:
 
     vitest-server run <file>           # warm rerun (~3-15s); JSON RunResult on stdout
@@ -39,14 +37,13 @@ If results look wrong (`(0 test)`, suite errors, post-config-edit weirdness), th
 
 `vitest-server` — Long-lived Vitest daemon + CLI client for fast story/unit reruns.
 
-| Command | Description | Positionals & flags |
-| --- | --- | --- |
-| `vitest-server serve` | Boot the long-lived Vitest daemon | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root<br>`--project <string>` — Vitest project filter (overrides vitest-server.config.ts)<br>`--prime <string>` (env: `VITEST_SERVER_PRIME_FILE`) — File to prime the storybook plugin on boot (overrides config) |
-| `vitest-server run` | Rerun a file against the running daemon | `<file>` — Spec/story path<br>`--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--grep <string>` — Vitest testNamePattern filter |
-| `vitest-server refresh` | Flush vitest transform cache + vite-node module cache and re-read config without restarting (keeps the warm vitest instance alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient. | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--hard <boolean>` (default: `false`) — Full shutdown + detached re-serve (loses daemon PID).<br>`--cwd <string>` (default: `(current directory)`) — Consumer project root passed to the re-spawned serve (--hard only).<br>`--project <string>` — Vitest project filter, passed to the re-spawned serve (--hard only).<br>`--prime <string>` (env: `VITEST_SERVER_PRIME_FILE`) — Prime file passed to the re-spawned serve (--hard only). |
-| `vitest-server health` | Daemon liveness check | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`) |
-| `vitest-server shutdown` | Stop the running daemon | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`) |
-| `vitest-server doctor` | Validate local install (node, peer dep, config, daemon liveness) | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
-| `vitest-server check` | Validate local install (deprecated alias for 'doctor') | `--port <number>` (default: `5179`, env: `VITEST_SERVER_PORT`)<br>`--host <string>` (default: `"127.0.0.1"`, env: `VITEST_SERVER_HOST`)<br>`--cwd <string>` (default: `(current directory)`)<br>`--json <boolean>` (default: `false`) — JSON output for agent parsing |
+- `vitest-server serve` — Boot the long-lived Vitest daemon
+- `vitest-server run <file>` — Rerun a file against the running daemon
+- `vitest-server refresh` — Flush vitest transform cache + vite-node module cache and re-read config without restarting (keeps the warm vitest instance alive). Pass --hard for a full shutdown + detached re-serve when soft refresh is insufficient.
+- `vitest-server health` — Daemon liveness check
+- `vitest-server shutdown` — Stop the running daemon
+- `vitest-server doctor` — Validate local install (node, peer dep, config, daemon liveness)
+
+Run `vitest-server <command> --help` for the full flags and options of any command.
 
 <!-- END cli-reference -->


### PR DESCRIPTION
Follow-up polish on #62/#63 per review feedback.

## 1. Lean CLI-reference block (was a noisy table)
The generated `<!-- cli-reference -->` block in each daemon skill is now a **bullet list**, not an exhaustive flags table:

- one line per command: `` `<server> <cmd> <required-positionals>` — description ``
- **flags and optional positionals omitted** (they were just noise)
- deprecated aliases (e.g. `check`) skipped
- a single trailing pointer: `` Run `<server> <command> --help` for the full flags and options. ``

Rationale: an agent can run `--help` when it actually needs a flag; the skill shouldn't carry every option inline.

## 2. Lifecycle advice moved to `davstack check` failure output
Removed the repeated blockquote ("ask the user to run `davstack start` in a separate terminal; don't run `serve` yourself") from all three daemon skills. That guidance only matters at the moment a daemon is reported down — so it now lives in `davstack check`'s `START_HINT`, shown only on failure. One source, surfaced exactly when relevant.

## Verification
- `davstack check` tests: 9/9 pass (failure output still asserts `davstack start`; terse success unchanged).
- Generators idempotent (two consecutive runs byte-identical).
- init bundled skills regenerated to match.

Changeset: `@davstack/tui` patch (START_HINT) + `@davstack/init` patch (regenerated skills). No daemon bump — the cli-block lives in `skills/`, not daemon `dist/`.