### PR TITLE
feat(init): install daemon skills project-local, orchestrator skills global

### DIFF
--- a/.changeset/split-skill-install.md
+++ b/.changeset/split-skill-install.md
@@ -1,0 +1,21 @@
+---
+"@davstack/init": minor
+---
+
+Split skill installation by location so daemon-skill doc links always resolve.
+
+Daemon skills (`logs-server`, `vitest-server`, `playwright-server`) reference
+`node_modules/@davstack/<pkg>/docs/...`, which only resolves from a specific
+project root. They now install **project-local** to `<root>/.claude/skills/`,
+and their doc links are rewritten to `../../../node_modules/@davstack/<pkg>/...`
+so they resolve directly from the installed file — locally, offline, and
+version-matched to the project's installed package.
+
+Orchestrator / open-agents skills (`diagnose`, `explore`, `fast-edit`) have no
+project-relative links and continue to install **globally** to
+`~/.claude/skills/`, available from every repo.
+
+On install, init also removes any stale **global** copy of a now-project-local
+daemon skill — but only the exact `SKILL.md` it previously generated (matched by
+a generated marker), and only removes the containing directory if it is then
+empty. Hand-authored skills and any other files are never touched.

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -206,7 +206,9 @@ async function main(): Promise<void> {
     for (const f of result.skipped) console.log(`  skipped ${f} (already exists)`)
     if (result.gitignoreUpdated) console.log("  updated .gitignore")
     else console.log("  .gitignore already has davstack lines")
-    for (const f of result.skillsInstalled) console.log(`  skill   ${f}`)
+    for (const f of result.projectSkills) console.log(`  skill   ${f} (project)`)
+    for (const f of result.globalSkills) console.log(`  skill   ${f} (global)`)
+    for (const f of result.removedGlobal) console.log(`  removed ${f} (stale global copy — now project-local)`)
   } else {
     console.log("Skipping scaffold (--no-scaffold).")
   }

--- a/packages/init/src/scaffold.ts
+++ b/packages/init/src/scaffold.ts
@@ -3,11 +3,22 @@
 // Writes .davstack/config/<tool>.config.ts files from templates and
 // appends the two gitignore lines that keep runtime files out of git
 // while keeping the committed config dir. Also installs the matching
-// SKILL.md files into ~/.claude/skills/<name>/ so Claude Code picks
-// them up globally.
+// SKILL.md files so Claude Code picks them up.
+//
+// Skills install to one of two roots depending on whether they reference
+// the project's installed packages:
+//   • Daemon skills (logs-server, vitest-server, playwright-server) link to
+//     node_modules/@davstack/<pkg>/docs/... — those paths only resolve from
+//     a specific project root, so these install PROJECT-LOCAL to
+//     <root>/.claude/skills/<name>/. (Their links are rewritten to
+//     ../../../node_modules/... by scripts/sync-init-skills.ts, resolving to
+//     <root>/node_modules from the installed file's location.)
+//   • Orchestrator / open-agents skills (diagnose, explore, fast-edit) have
+//     no project-relative links, so they install GLOBALLY to
+//     ~/.claude/skills/<name>/ and are available from every repo.
 
 import { existsSync } from "node:fs"
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, readdir, readFile, rm, rmdir, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -32,6 +43,16 @@ const TOOL_SKILLS: Record<Tool, string[]> = {
 
 const ALWAYS_SKILLS = ["diagnose"]
 
+// Skills that link to node_modules/@davstack/<pkg>/docs/... — those links
+// only resolve from a specific project root, so these install PROJECT-LOCAL.
+// (Matches exactly the skills sync-init-skills.ts rewrites doc links in.)
+// Everything else installs globally.
+const PROJECT_LOCAL_SKILLS = new Set([
+  "logs-server",
+  "vitest-server",
+  "playwright-server",
+])
+
 const here = path.dirname(fileURLToPath(import.meta.url))
 const TEMPLATE_DIR = path.join(here, "templates")
 const SKILL_DIR = path.join(here, "skills")
@@ -42,7 +63,11 @@ export interface ScaffoldResult {
   written: string[]
   skipped: string[]
   gitignoreUpdated: boolean
-  skillsInstalled: string[]
+  // Absolute SKILL.md paths, split by install location.
+  globalSkills: string[]
+  projectSkills: string[]
+  // Stale global daemon-skill dirs removed (migrated to project-local).
+  removedGlobal: string[]
 }
 
 async function loadTemplate(tool: Tool): Promise<string> {
@@ -78,9 +103,13 @@ export async function scaffold(
   }
 
   const gitignoreUpdated = await ensureGitignore(root)
-  const skillsInstalled = await installSkills(tools, opts.allSkills)
+  const { globalSkills, projectSkills, removedGlobal } = await installSkills(
+    root,
+    tools,
+    opts.allSkills,
+  )
 
-  return { written, skipped, gitignoreUpdated, skillsInstalled }
+  return { written, skipped, gitignoreUpdated, globalSkills, projectSkills, removedGlobal }
 }
 
 export async function ensureGitignore(root: string): Promise<boolean> {
@@ -102,12 +131,61 @@ export async function ensureGitignore(root: string): Promise<boolean> {
   return true
 }
 
+export interface InstalledSkills {
+  globalSkills: string[]
+  projectSkills: string[]
+  // Stale global copies of now-project-local daemon skills that were removed.
+  removedGlobal: string[]
+}
+
+// Marker that scripts/sync-init-skills.ts stamps into every generated skill.
+// We only ever delete a global SKILL.md that carries this marker, so a user's
+// hand-authored skill of the same name is never touched.
+const GENERATED_MARKER = "GENERATED from skills/"
+
+// Earlier init versions installed daemon skills GLOBALLY. Now they're
+// project-local, so a stale global copy would shadow/duplicate the project
+// one. Clean it up — but VERY conservatively, since this deletes from the
+// user's home dir:
+//   1. only the three known daemon-skill names (callers pass those),
+//   2. only when ~/.claude/skills/<skill>/SKILL.md actually exists,
+//   3. only when that file carries our generated marker (never a hand-edited
+//      or unrelated skill), and
+//   4. we delete only that one SKILL.md file — then remove the dir solely if
+//      it is now empty, so any extra files the user dropped there survive.
+async function removeStaleGlobalSkill(skill: string): Promise<string | null> {
+  const dir = path.join(homedir(), ".claude", "skills", skill)
+  const file = path.join(dir, "SKILL.md")
+  if (!existsSync(file)) return null
+  const content = await readFile(file, "utf8")
+  if (!content.includes(GENERATED_MARKER)) return null
+
+  await rm(file, { force: true })
+  // Drop the now-orphaned dir only if empty; leave it (and report nothing
+  // extra) if the user keeps other files alongside it.
+  try {
+    const rest = await readdir(dir)
+    if (rest.length === 0) await rmdir(dir)
+  } catch {
+    // readdir/rmdir race or perms — harmless; the SKILL.md is already gone.
+  }
+  return file
+}
+
 // Install SKILL.md for each selected tool's skills, plus the always-on
 // orchestrator skills. Pass `all=true` to install every bundled skill
 // regardless of selected tools (--all-skills). Always overwrites so
 // re-running init bumps users to the latest skill content shipped with
 // the installed init version.
-export async function installSkills(tools: Tool[], all = false): Promise<string[]> {
+//
+// Each skill lands in one of two roots (see file header): PROJECT_LOCAL_SKILLS
+// go to <root>/.claude/skills/<name>/ so their node_modules doc links resolve
+// against this project; the rest go to ~/.claude/skills/<name>/ globally.
+export async function installSkills(
+  root: string,
+  tools: Tool[],
+  all = false,
+): Promise<InstalledSkills> {
   const skills = new Set<string>(ALWAYS_SKILLS)
   if (all) {
     for (const list of Object.values(TOOL_SKILLS)) for (const s of list) skills.add(s)
@@ -115,17 +193,32 @@ export async function installSkills(tools: Tool[], all = false): Promise<string[
     for (const tool of tools) for (const s of TOOL_SKILLS[tool]) skills.add(s)
   }
 
-  const root = path.join(homedir(), ".claude", "skills")
-  const installed: string[] = []
+  const globalRoot = path.join(homedir(), ".claude", "skills")
+  const projectRoot = path.join(root, ".claude", "skills")
+  // If the project root is the home dir, project-local and global resolve to
+  // the same path — skip the stale-copy cleanup so we never delete the skill
+  // we just wrote there.
+  const projectIsGlobal = path.resolve(projectRoot) === path.resolve(globalRoot)
+
+  const globalSkills: string[] = []
+  const projectSkills: string[] = []
+  const removedGlobal: string[] = []
   for (const skill of skills) {
     const src = path.join(SKILL_DIR, `${skill}.md`)
     if (!existsSync(src)) continue
-    const dir = path.join(root, skill)
+    const isProjectLocal = PROJECT_LOCAL_SKILLS.has(skill)
+    const dir = path.join(isProjectLocal ? projectRoot : globalRoot, skill)
     await mkdir(dir, { recursive: true })
     const target = path.join(dir, "SKILL.md")
     const content = await readFile(src, "utf8")
     await writeFile(target, content, "utf8")
-    installed.push(target)
+    ;(isProjectLocal ? projectSkills : globalSkills).push(target)
+    // For each daemon skill we just placed project-local, sweep away the
+    // stale global copy an older init may have left behind.
+    if (isProjectLocal && !projectIsGlobal) {
+      const removed = await removeStaleGlobalSkill(skill)
+      if (removed) removedGlobal.push(removed)
+    }
   }
-  return installed
+  return { globalSkills, projectSkills, removedGlobal }
 }

--- a/packages/init/src/scaffold.ts
+++ b/packages/init/src/scaffold.ts
@@ -138,27 +138,49 @@ export interface InstalledSkills {
   removedGlobal: string[]
 }
 
-// Marker that scripts/sync-init-skills.ts stamps into every generated skill.
-// We only ever delete a global SKILL.md that carries this marker, so a user's
-// hand-authored skill of the same name is never touched.
-const GENERATED_MARKER = "GENERATED from skills/"
+// Per-skill marker that scripts/sync-init-skills.ts stamps into the generated
+// skill. We only ever delete a global SKILL.md that carries the EXACT marker
+// for that skill name, so a user's hand-authored skill — or any unrelated
+// file — is never touched.
+const generatedMarker = (skill: string) =>
+  `GENERATED from skills/${skill}/SKILL.md by scripts/sync-init-skills.ts`
+
+// Two filesystem paths point at the same location. Case-insensitive on
+// Windows/macOS (where the FS folds case), so e.g. `c:\…` vs `C:\…` — which
+// node returns inconsistently for cwd vs os.homedir() — compare equal.
+function samePath(a: string, b: string): boolean {
+  const ra = path.resolve(a)
+  const rb = path.resolve(b)
+  if (process.platform === "win32" || process.platform === "darwin") {
+    return ra.toLowerCase() === rb.toLowerCase()
+  }
+  return ra === rb
+}
 
 // Earlier init versions installed daemon skills GLOBALLY. Now they're
 // project-local, so a stale global copy would shadow/duplicate the project
 // one. Clean it up — but VERY conservatively, since this deletes from the
 // user's home dir:
 //   1. only the three known daemon-skill names (callers pass those),
-//   2. only when ~/.claude/skills/<skill>/SKILL.md actually exists,
-//   3. only when that file carries our generated marker (never a hand-edited
-//      or unrelated skill), and
-//   4. we delete only that one SKILL.md file — then remove the dir solely if
+//   2. never when the global path is the project path we just wrote to
+//      (case-insensitive) — defense-in-depth against deleting our own file,
+//   3. only when ~/.claude/skills/<skill>/SKILL.md actually exists,
+//   4. only when that file carries the EXACT generated marker for this skill
+//      (never a hand-edited or unrelated skill), and
+//   5. we delete only that one SKILL.md file — then remove the dir solely if
 //      it is now empty, so any extra files the user dropped there survive.
-async function removeStaleGlobalSkill(skill: string): Promise<string | null> {
+// `justWrote` is the project-local SKILL.md we just installed; we refuse to
+// touch any global path that resolves to it.
+async function removeStaleGlobalSkill(
+  skill: string,
+  justWrote: string,
+): Promise<string | null> {
   const dir = path.join(homedir(), ".claude", "skills", skill)
   const file = path.join(dir, "SKILL.md")
+  if (samePath(file, justWrote)) return null
   if (!existsSync(file)) return null
   const content = await readFile(file, "utf8")
-  if (!content.includes(GENERATED_MARKER)) return null
+  if (!content.includes(generatedMarker(skill))) return null
 
   await rm(file, { force: true })
   // Drop the now-orphaned dir only if empty; leave it (and report nothing
@@ -197,8 +219,9 @@ export async function installSkills(
   const projectRoot = path.join(root, ".claude", "skills")
   // If the project root is the home dir, project-local and global resolve to
   // the same path — skip the stale-copy cleanup so we never delete the skill
-  // we just wrote there.
-  const projectIsGlobal = path.resolve(projectRoot) === path.resolve(globalRoot)
+  // we just wrote there. (samePath folds case so a `c:\…` vs `C:\…` drive
+  // letter, which node returns inconsistently on Windows, still matches.)
+  const projectIsGlobal = samePath(projectRoot, globalRoot)
 
   const globalSkills: string[] = []
   const projectSkills: string[] = []
@@ -216,7 +239,7 @@ export async function installSkills(
     // For each daemon skill we just placed project-local, sweep away the
     // stale global copy an older init may have left behind.
     if (isProjectLocal && !projectIsGlobal) {
-      const removed = await removeStaleGlobalSkill(skill)
+      const removed = await removeStaleGlobalSkill(skill, target)
       if (removed) removedGlobal.push(removed)
     }
   }

--- a/packages/init/src/skills/logs-server.md
+++ b/packages/init/src/skills/logs-server.md
@@ -12,8 +12,6 @@ description: >-
 
 <!-- GENERATED from skills/logs-server/SKILL.md by scripts/sync-init-skills.ts — DO NOT EDIT BY HAND -->
 
-> Doc links in this skill are written relative to your project root (where `node_modules/` lives), not to this file.
-
 First run `davstack check` to confirm the daemon is running.
 
 ## The read path is sqlite3
@@ -103,12 +101,12 @@ For hypothesis-driven probe-then-slice debugging, see `writing-logs.md`.
 
 ## Reference
 
-- [`README.md`](node_modules/@davstack/logs-server/README.md) — overview, install, why
-- [`docs/setup.md`](node_modules/@davstack/logs-server/docs/setup.md) — config file, transmitter setup, auto-instrumentation
-- [`docs/writing-logs.md`](node_modules/@davstack/logs-server/docs/writing-logs.md) — queryable shape, hypothesis-driven probes
-- [`docs/reading-logs.md`](node_modules/@davstack/logs-server/docs/reading-logs.md) — schema details + ready-to-paste recipes
-- [`docs/transmitter-wiring.md`](node_modules/@davstack/logs-server/docs/transmitter-wiring.md) — route a session's logs to its own DB
-- [`docs/session-views.md`](node_modules/@davstack/logs-server/docs/session-views.md) — per-DB SQL views (`dbg_*`) for keeping queries short across a session
+- [`README.md`](../../../node_modules/@davstack/logs-server/README.md) — overview, install, why
+- [`docs/setup.md`](../../../node_modules/@davstack/logs-server/docs/setup.md) — config file, transmitter setup, auto-instrumentation
+- [`docs/writing-logs.md`](../../../node_modules/@davstack/logs-server/docs/writing-logs.md) — queryable shape, hypothesis-driven probes
+- [`docs/reading-logs.md`](../../../node_modules/@davstack/logs-server/docs/reading-logs.md) — schema details + ready-to-paste recipes
+- [`docs/transmitter-wiring.md`](../../../node_modules/@davstack/logs-server/docs/transmitter-wiring.md) — route a session's logs to its own DB
+- [`docs/session-views.md`](../../../node_modules/@davstack/logs-server/docs/session-views.md) — per-DB SQL views (`dbg_*`) for keeping queries short across a session
 
 ## CLI reference
 

--- a/packages/init/src/skills/playwright-server.md
+++ b/packages/init/src/skills/playwright-server.md
@@ -12,8 +12,6 @@ description: >-
 
 <!-- GENERATED from skills/playwright-server/SKILL.md by scripts/sync-init-skills.ts — DO NOT EDIT BY HAND -->
 
-> Doc links in this skill are written relative to your project root (where `node_modules/` lives), not to this file.
-
 Boot once per session, then drive cheaply. First run `davstack check` to
 confirm the daemon is running.
 
@@ -27,17 +25,17 @@ Exit `0` = pass, `1` = fail. Specs are loaded as real ES modules — full
 TypeScript, multiple `test()` blocks, `test.describe`, `beforeEach` /
 `afterEach`, and `test.use({ storageState })` all work. Custom
 `test.extend(...)` fixtures are the one current gap. See
-[`usage.md`](node_modules/@davstack/playwright-server/docs/usage.md) for details.
+[`usage.md`](../../../node_modules/@davstack/playwright-server/docs/usage.md) for details.
 
 If results look wrong (blank window, cold-boot crash, `no test() block found`, 401 redirects, daemon exit 1), the failure is usually in the daemon, not your code — check `troubleshooting.md` before iterating, or fall back to `playwright test`.
 
 ## Reference
 
-- [`README.md`](node_modules/@davstack/playwright-server/README.md) — overview, install, why
-- [`docs/setup.md`](node_modules/@davstack/playwright-server/docs/setup.md) — config file, defaults, peer-dep, sanity check
-- [`docs/usage.md`](node_modules/@davstack/playwright-server/docs/usage.md) — CLI verbs, HTTP API, codegen-paste workflow, agent-loop pattern
-- [`docs/auth.md`](node_modules/@davstack/playwright-server/docs/auth.md) — `refreshAuth` seam + `storageStatePath` lifecycle
-- [`docs/troubleshooting.md`](node_modules/@davstack/playwright-server/docs/troubleshooting.md) — the daemon-vs-code triage tree
+- [`README.md`](../../../node_modules/@davstack/playwright-server/README.md) — overview, install, why
+- [`docs/setup.md`](../../../node_modules/@davstack/playwright-server/docs/setup.md) — config file, defaults, peer-dep, sanity check
+- [`docs/usage.md`](../../../node_modules/@davstack/playwright-server/docs/usage.md) — CLI verbs, HTTP API, codegen-paste workflow, agent-loop pattern
+- [`docs/auth.md`](../../../node_modules/@davstack/playwright-server/docs/auth.md) — `refreshAuth` seam + `storageStatePath` lifecycle
+- [`docs/troubleshooting.md`](../../../node_modules/@davstack/playwright-server/docs/troubleshooting.md) — the daemon-vs-code triage tree
 
 ## CLI reference
 

--- a/packages/init/src/skills/vitest-server.md
+++ b/packages/init/src/skills/vitest-server.md
@@ -11,8 +11,6 @@ description: >-
 
 <!-- GENERATED from skills/vitest-server/SKILL.md by scripts/sync-init-skills.ts — DO NOT EDIT BY HAND -->
 
-> Doc links in this skill are written relative to your project root (where `node_modules/` lives), not to this file.
-
 Boot once per session, then rerun cheaply. First run `davstack check` to
 confirm the daemon is running.
 
@@ -30,10 +28,10 @@ If results look wrong (`(0 test)`, suite errors, post-config-edit weirdness), th
 
 ## Reference
 
-- [`README.md`](node_modules/@davstack/vitest-server/README.md) — overview, install, why
-- [`docs/setup.md`](node_modules/@davstack/vitest-server/docs/setup.md) — config file, runtime matrix, `primeFile` semantics
-- [`docs/usage.md`](node_modules/@davstack/vitest-server/docs/usage.md) — CLI verbs, HTTP API, `RunResult` shape, agent TDD loop
-- [`docs/troubleshooting.md`](node_modules/@davstack/vitest-server/docs/troubleshooting.md) — the daemon-vs-code triage tree
+- [`README.md`](../../../node_modules/@davstack/vitest-server/README.md) — overview, install, why
+- [`docs/setup.md`](../../../node_modules/@davstack/vitest-server/docs/setup.md) — config file, runtime matrix, `primeFile` semantics
+- [`docs/usage.md`](../../../node_modules/@davstack/vitest-server/docs/usage.md) — CLI verbs, HTTP API, `RunResult` shape, agent TDD loop
+- [`docs/troubleshooting.md`](../../../node_modules/@davstack/vitest-server/docs/troubleshooting.md) — the daemon-vs-code triage tree
 
 ## CLI reference
 

--- a/scripts/sync-init-skills.ts
+++ b/scripts/sync-init-skills.ts
@@ -37,18 +37,24 @@ const SKILLS = [
 
 // Rewrite canonical repo-relative doc links to the consumer's installed
 // package. Canonical links look like `../../packages/<pkg>/docs/<file>.md`
-// or `../../packages/<pkg>/README.md`; on the consumer machine the
-// matching files live under node_modules/@davstack/<pkg>/..., so the
-// installed skill's links resolve locally/offline and version-matched.
-// Reports whether any link was rewritten so we can append the
-// project-root hint (below) only to skills that actually carry such links.
+// or `../../packages/<pkg>/README.md`; on the consumer machine the matching
+// files live under <project>/node_modules/@davstack/<pkg>/....
+//
+// Skills carrying these links install PROJECT-LOCAL at
+// <root>/.claude/skills/<name>/SKILL.md (see packages/init scaffold.ts), so
+// from the installed file `../../../` climbs back to the project root and
+// `../../../node_modules/@davstack/<pkg>/...` resolves to the project's
+// installed package — locally, offline, and version-matched. The `../../../`
+// depth is bound to that install location; keep the two in sync.
+const PROJECT_ROOT_PREFIX = "../../../"
+
 function rewriteLinks(content: string): { text: string; changed: boolean } {
   let changed = false
   const text = content.replace(
     /\.\.\/\.\.\/packages\/([^/)\s]+)\//g,
     (_m, pkg: string) => {
       changed = true
-      return `node_modules/@davstack/${pkg}/`
+      return `${PROJECT_ROOT_PREFIX}node_modules/@davstack/${pkg}/`
     },
   )
   return { text, changed }
@@ -68,13 +74,6 @@ function splitFrontmatter(content: string): { frontmatter: string; body: string 
 const GEN_COMMENT = (name: string) =>
   `<!-- GENERATED from skills/${name}/SKILL.md by scripts/sync-init-skills.ts — DO NOT EDIT BY HAND -->`
 
-// Installed skills live at ~/.claude/skills/<name>/SKILL.md, but their doc
-// links are bare node_modules/@davstack/... paths — i.e. relative to the
-// consumer's PROJECT ROOT (where node_modules lives), not to this file.
-// Spell that out so the link target is unambiguous to the reader.
-const PROJECT_ROOT_HINT =
-  "> Doc links in this skill are written relative to your project root (where `node_modules/` lives), not to this file."
-
 async function main() {
   for (const name of SKILLS) {
     const src = path.join(CANONICAL_DIR, name, "SKILL.md")
@@ -84,13 +83,12 @@ async function main() {
     // regardless of the canonical file's on-disk line endings.
     const normalized = canonical.replace(/\r\n/g, "\n")
     const { frontmatter, body } = splitFrontmatter(normalized)
-    const { text: rewrittenBody, changed } = rewriteLinks(body)
+    const { text: rewrittenBody } = rewriteLinks(body)
 
-    // Note block goes after frontmatter: generated marker, plus the
-    // project-root hint when this skill carries rewritten doc links.
-    const note = changed
-      ? `${GEN_COMMENT(name)}\n\n${PROJECT_ROOT_HINT}\n`
-      : `${GEN_COMMENT(name)}\n`
+    // Note block goes after frontmatter: just the generated marker. The
+    // rewritten doc links are project-root-relative (../../../node_modules/…)
+    // and resolve directly from the installed file, so no extra hint is needed.
+    const note = `${GEN_COMMENT(name)}\n`
     const cleanBody = rewrittenBody.replace(/^\n+/, "")
     const out = frontmatter
       ? `${frontmatter}\n${note}\n${cleanBody}`


### PR DESCRIPTION
## What

Splits skill installation by location so daemon-skill doc links **always resolve**.

| Skill group | Skills | Installs to | Why |
|---|---|---|---|
| Daemon | `logs-server`, `vitest-server`, `playwright-server` | **project-local** `<root>/.claude/skills/` | their docs live in the project's `node_modules/@davstack/<pkg>/docs/...` |
| Orchestrator / open-agents | `diagnose`, `explore`, `fast-edit` | **global** `~/.claude/skills/` | no project-relative links — useful everywhere |

Daemon-skill doc links are now rewritten by `scripts/sync-init-skills.ts` to `../../../node_modules/@davstack/<pkg>/...`, which resolves **directly from the installed file** (`<root>/.claude/skills/<name>/SKILL.md` → `<root>/node_modules`) — locally, offline, version-matched. The old project-root caveat hint is dropped (no longer needed).

## Stale-copy cleanup (conservative)

Earlier init versions installed daemon skills globally. To avoid a global copy shadowing the new project-local one, install removes the stale global copy — but only:
1. for the three known daemon-skill names,
2. when `~/.claude/skills/<skill>/SKILL.md` exists **and carries our generated marker** (never hand-authored/unrelated skills),
3. deleting only that one `SKILL.md`, then `rmdir` **only if the dir is now empty** (sibling files survive),
4. skipped entirely when project root == home dir.

## Verification (isolated e2e — real `~/.claude` untouched)

Ran the published-style `davstack-init` flow against a temp project + isolated HOME:
- ✅ daemon skills → project `.claude/skills/`; orchestrator skills → global
- ✅ frontmatter on line 1 of every skill
- ✅ **16/16 doc links resolve** to real files under the project's `node_modules` (logs 6/6, vitest 4/4, playwright 6/6)
- ✅ generated stale global copy removed; hand-authored same-name skill **preserved**; sibling user file alongside a generated `SKILL.md` **survives**
- ✅ `sync-init-skills.ts` idempotent (hash-stable on re-run)

## Files
- `packages/init/src/scaffold.ts` — split install + conservative cleanup
- `packages/init/src/index.ts` — report project/global/removed paths
- `scripts/sync-init-skills.ts` — rewrite links to `../../../node_modules/...`; drop project-root hint
- `packages/init/src/skills/{logs,vitest,playwright}-server.md` — regenerated
- `.changeset/split-skill-install.md` — `@davstack/init` minor
