### PR TITLE
feat(logs-server): ingest traces (spans) as first-class rows

### DIFF
--- a/.changeset/logs-server-trace-ingestion.md
+++ b/.changeset/logs-server-trace-ingestion.md
@@ -1,0 +1,26 @@
+---
+"@davstack/logs-server": minor
+---
+
+Ingest traces (spans) as first-class rows alongside logs.
+
+The sink previously dropped every `type:"transaction"`/`type:"span"` envelope
+item and only persisted logs. It now ingests Sentry tracing envelopes into the
+same `logs` table, discriminated by a new `kind` column (`'log' | 'span'`).
+
+A transaction event expands to one row per span: the root span (from
+`contexts.trace`, timed by the event's top-level start/timestamp) plus one row
+per `spans[]` child. Each span row carries `kind:'span'`, `ts` =
+`start_timestamp`, and a real `duration_ms` column (the headline metric, so
+spans sort by latency in plain SQL). Span-specific fields (`op`, `status`,
+`parent_span_id`, `description`, `duration_ms`) are flattened into the
+`json_extract`-queryable `attrs` JSON, and the span's verbatim object is kept in
+`data`. The `davstack-logs.db` routing attribute and `diag.project`/`diag.run_id`
+attribution are honored for spans too.
+
+Fully backward compatible: every existing log path still produces `kind:'log'`
+rows with `duration_ms` NULL, and an idempotent migration adds the `kind` /
+`duration_ms` columns to pre-existing DBs (existing rows default to `'log'`).
+
+Query spans with e.g. `SELECT msg, duration_ms FROM logs WHERE kind='span'
+ORDER BY duration_ms DESC`.

--- a/packages/logs-server/README.md
+++ b/packages/logs-server/README.md
@@ -1,11 +1,11 @@
 # @davstack/logs-server
 
-Local Sentry-shaped app -> sqlite log sink.
+Local Sentry-shaped app -> sqlite telemetry sink (logs **and** traces).
 
 ## Why
 
-- **E2E traceability.** Frontend + backend + workers POST to the same `.davstack/logs/default.db`; `trace_id` follows requests across services.
-- **Zero infra.** Integrates into existing sentry logger client for auto-instrumentation and low effort setup.
+- **E2E traceability.** Frontend + backend + workers POST to the same `.davstack/logs/default.db`; `trace_id` follows requests across services. Logs and trace spans land in one table, discriminated by a `kind` column (`'log' | 'span'`).
+- **Zero infra.** Integrates into existing sentry logger client for auto-instrumentation and low effort setup. Set `tracesSampleRate` and spans flow into the same sink as logs — no extra wiring.
 - **Optimized for Agents.** Compact one-row-per-line by default — coding agents read it without grouping passes.
 
 ## Install & setup (1 min)
@@ -74,6 +74,38 @@ ts          msg                user_id
 ----------  -----------------  -------
 1716480923  user clicked save  42
 ```
+
+5. Query trace spans — `kind='span'` rows have a real `duration_ms` column, so the slowest spans sort in plain SQL. `op`/`status`/`parent_span_id` are flattened into `attrs`.
+
+```bash
+sqlite3 -header -column .davstack/logs/default.db "
+  SELECT msg, duration_ms,
+         json_extract(attrs, '\$.op')     AS op,
+         json_extract(attrs, '\$.status') AS status
+  FROM logs
+  WHERE kind = 'span'
+  ORDER BY duration_ms DESC
+  LIMIT 10;
+"
+```
+
+(Logs and spans share the `trace_id` column, so a single `WHERE trace_id = ?` slices the full request timeline across both.)
+
+## Schema
+
+One `logs` table per session DB. Key columns:
+
+| column        | logs                     | spans (`kind='span'`)                         |
+| ------------- | ------------------------ | --------------------------------------------- |
+| `kind`        | `'log'`                  | `'span'`                                       |
+| `ts`          | log `timestamp`          | span `start_timestamp`                         |
+| `duration_ms` | `NULL`                   | `(timestamp - start_timestamp) * 1000`         |
+| `msg`         | log `body`               | span `description` \|\| `op` (root: tx name)   |
+| `level`       | OTel level               | `''`                                           |
+| `data`        | verbatim log item        | verbatim span / transaction-trace object       |
+| `attrs`       | flat attrs (unwrapped)   | flat span data + `op`/`status`/`parent_span_id`/`description`/`duration_ms` |
+
+A transaction event expands to one row per span: the root (from `contexts.trace`) plus one per `spans[]` child.
 
 ## Docs
 

--- a/packages/logs-server/__tests__/bun-only/db.test.ts
+++ b/packages/logs-server/__tests__/bun-only/db.test.ts
@@ -10,6 +10,7 @@ function row(over: Partial<LogRow>): LogRow {
   return {
     ts: 1_700_000_000.0,
     recv_ts: Date.now(),
+    kind: 'log',
     project: 'proj-a',
     service: 'sentry.python',
     run_id: 'run-1',
@@ -22,6 +23,7 @@ function row(over: Partial<LogRow>): LogRow {
     data: '{"raw":"item"}',
     attrs: null,
     tag: null,
+    duration_ms: null,
     ...over,
   };
 }
@@ -111,6 +113,79 @@ test('openDb migrates pre-2.2 schema: backfills attrs column, drops logs_v view'
   require('node:fs').rmSync(tmp, { force: true });
   require('node:fs').rmSync(`${tmp}-wal`, { force: true });
   require('node:fs').rmSync(`${tmp}-shm`, { force: true });
+});
+
+test('openDb stores kind + duration_ms columns; spans round-trip and sort by duration', () => {
+  const db = openDb(':memory:');
+  const cols = db.query('PRAGMA table_info(logs)').all() as { name: string }[];
+  expect(cols.some((c) => c.name === 'kind')).toBe(true);
+  expect(cols.some((c) => c.name === 'duration_ms')).toBe(true);
+  insertLogs(db, [
+    row({ kind: 'log', msg: 'a-log' }),
+    row({ kind: 'span', msg: 'fast', duration_ms: 5 }),
+    row({ kind: 'span', msg: 'slow', duration_ms: 120 }),
+  ]);
+  // kind discriminates; duration_ms is a real sortable column
+  const spans = db
+    .query("SELECT msg FROM logs WHERE kind = 'span' ORDER BY duration_ms DESC")
+    .all() as { msg: string }[];
+  expect(spans.map((r) => r.msg)).toEqual(['slow', 'fast']);
+  const logCount = (
+    db.query("SELECT count(*) c FROM logs WHERE kind = 'log'").get() as { c: number }
+  ).c;
+  expect(logCount).toBe(1);
+});
+
+test('openDb migrates pre-2.7 schema: adds kind/duration_ms, existing rows → kind=log', () => {
+  // Hand-build a 2.6-era table (has attrs, no kind/duration_ms) with rows that
+  // predate trace ingestion. The migration must add the columns and default
+  // every existing row to kind='log' with a NULL duration.
+  const { Database } = require('bun:sqlite');
+  const legacy = new Database(':memory:');
+  legacy.exec(`CREATE TABLE logs (
+    id INTEGER PRIMARY KEY, ts REAL, recv_ts REAL, project TEXT, service TEXT,
+    run_id TEXT, trace_id TEXT, span_id TEXT, level TEXT, severity_number INTEGER,
+    logger TEXT, msg TEXT, data TEXT, attrs TEXT, tag TEXT
+  )`);
+  legacy.exec(`INSERT INTO logs (ts, recv_ts, project, msg, data) VALUES
+    (1, 1, 'p', 'old-one', '{"body":"x"}'),
+    (2, 2, 'p', 'old-two', '{"body":"y"}')`);
+  const tmp = `/tmp/migrate-kind-${process.pid}-${Date.now()}.db`;
+  legacy.exec(`VACUUM INTO '${tmp}'`);
+  legacy.close();
+
+  const db = openDb(tmp);
+  const cols = db.query('PRAGMA table_info(logs)').all() as { name: string }[];
+  expect(cols.some((c) => c.name === 'kind')).toBe(true);
+  expect(cols.some((c) => c.name === 'duration_ms')).toBe(true);
+  const rows = db
+    .query('SELECT kind, duration_ms FROM logs ORDER BY id')
+    .all() as { kind: string; duration_ms: unknown }[];
+  expect(rows.map((r) => r.kind)).toEqual(['log', 'log']);
+  expect(rows.every((r) => r.duration_ms === null)).toBe(true);
+
+  // Idempotent — a second open is a no-op (no throw, no schema drift), and a
+  // freshly inserted span coexists with the migrated logs.
+  db.close();
+  const db2 = openDb(tmp);
+  insertLogs(db2, [row({ kind: 'span', msg: 'new-span', duration_ms: 42, ts: 3, recv_ts: 3 })]);
+  const counts = db2
+    .query("SELECT kind, count(*) c FROM logs GROUP BY kind ORDER BY kind")
+    .all() as { kind: string; c: number }[];
+  expect(counts).toEqual([
+    { kind: 'log', c: 2 },
+    { kind: 'span', c: 1 },
+  ]);
+  db2.close();
+  // Best-effort cleanup. On Windows the WAL/shm handles can linger a beat after
+  // close(), so a rm race can EBUSY — swallow it (the OS reclaims the temp file).
+  for (const p of [tmp, `${tmp}-wal`, `${tmp}-shm`]) {
+    try {
+      require('node:fs').rmSync(p, { force: true });
+    } catch {
+      /* temp file still locked — leave it for the OS */
+    }
+  }
 });
 
 test('insertLogs batch-inserts and rows are retrievable with autoincrement id', () => {

--- a/packages/logs-server/__tests__/envelope.test.ts
+++ b/packages/logs-server/__tests__/envelope.test.ts
@@ -187,3 +187,191 @@ test('attrs excludes the davstack-logs.db routing key', () => {
   expect(flat['davstack-logs.db']).toBeUndefined();
   expect(flat.seam).toBe('after-fetch');
 });
+
+//* MARK: Transactions (spans)
+
+// Trace ingestion. The fixture below was captured live from @sentry/node
+// 10.16.0 (a real wire envelope, not a guess — see the parser's header comment
+// for the captured shape). A transaction item is `{type:"transaction"}` whose
+// payload is the transaction *event*: the ROOT span lives in `contexts.trace`
+// and is timed by the event's TOP-LEVEL start_timestamp/timestamp (the trace
+// context itself carries no timing); child spans live in `spans[]` and are
+// self-timed. Span `data` is a PLAIN object — NOT the {value,type} log wrapper.
+
+// One transaction envelope (item header + payload), modelled on the real wire.
+function txEnvelope(tx: Record<string, unknown>, sdkName = 'sentry.javascript.node') {
+  return [
+    JSON.stringify({ sdk: { name: sdkName, version: '10.16.0' }, trace: { trace_id: 't'.repeat(32) } }),
+    JSON.stringify({ type: 'transaction' }),
+    JSON.stringify(tx),
+  ].join('\n');
+}
+
+// A faithful transaction event: a root http.server span with two children.
+function transaction(over: Record<string, unknown> = {}) {
+  return {
+    contexts: {
+      trace: {
+        span_id: '90c3461b7a51e4b6',
+        trace_id: 'cf8a364a6a3a7fbf3d6dcf31a1710bec',
+        data: {
+          'sentry.source': 'custom',
+          'sentry.op': 'http.server',
+          'sentry.origin': 'auto.http.otel.http',
+          'diag.project': 'titanium',
+          'diag.run_id': 'run-7',
+          'diag.tag': 'H2',
+        },
+        origin: 'auto.http.otel.http',
+        op: 'http.server',
+        status: 'ok',
+      },
+    },
+    spans: [
+      {
+        span_id: 'effb0f75cd2f106a',
+        trace_id: 'cf8a364a6a3a7fbf3d6dcf31a1710bec',
+        data: { 'sentry.origin': 'manual', 'sentry.op': 'db.sql.query', 'db.system': 'postgresql' },
+        description: 'db.query users',
+        parent_span_id: '90c3461b7a51e4b6',
+        start_timestamp: 1780233556.335,
+        timestamp: 1780233556.3555682, // ~20.6ms
+        status: 'ok',
+        op: 'db.sql.query',
+        origin: 'manual',
+      },
+      {
+        span_id: 'e0207084d4bbc6b7',
+        trace_id: 'cf8a364a6a3a7fbf3d6dcf31a1710bec',
+        data: { 'sentry.origin': 'manual', 'sentry.op': 'http.client' },
+        description: 'http.client fetch',
+        parent_span_id: '90c3461b7a51e4b6',
+        start_timestamp: 1780233556.357,
+        timestamp: 1780233556.368539, // ~11.5ms
+        status: 'ok',
+        op: 'http.client',
+        origin: 'manual',
+      },
+    ],
+    start_timestamp: 1780233556.333,
+    timestamp: 1780233556.3694255, // root ~36.4ms
+    transaction: 'GET /api/test',
+    type: 'transaction',
+    ...over,
+  };
+}
+
+test('a transaction with N child spans yields N+1 span rows, root first, in order', () => {
+  const { rows, skipped } = parseEnvelope(txEnvelope(transaction()));
+  expect(skipped).toBe(0);
+  expect(rows).toHaveLength(3); // root + 2 children
+  expect(rows.every((r) => r.kind === 'span')).toBe(true);
+  // root row: msg = transaction name, timed by the event's top-level window
+  const root = rows[0];
+  expect(root.msg).toBe('GET /api/test');
+  expect(root.span_id).toBe('90c3461b7a51e4b6');
+  expect(root.ts).toBe(1780233556.333);
+  expect(root.level).toBe(''); // spans carry no level
+  expect(root.severity_number).toBe(0);
+  expect(root.duration_ms).toBeCloseTo(36.4255, 3);
+  // children, in array order, self-timed
+  expect(rows.slice(1).map((r) => r.msg)).toEqual(['db.query users', 'http.client fetch']);
+  expect(rows[1].duration_ms).toBeCloseTo(20.5682, 3);
+  expect(rows[2].duration_ms).toBeCloseTo(11.539, 3);
+});
+
+test('span rows surface op/status/parent/description/duration_ms into json-queryable attrs', () => {
+  const { rows } = parseEnvelope(txEnvelope(transaction()));
+  const child = JSON.parse(rows[1].attrs as string) as Record<string, unknown>;
+  expect(child.op).toBe('db.sql.query');
+  expect(child.status).toBe('ok');
+  expect(child.parent_span_id).toBe('90c3461b7a51e4b6');
+  expect(child.description).toBe('db.query users');
+  expect(child.duration_ms).toBeCloseTo(20.5682, 3);
+  // the span's own plain data is merged in (NOT unwrapped — it's already plain)
+  expect(child['db.system']).toBe('postgresql');
+});
+
+test('span attribution: project/run_id/logger pulled from span data, tag from diag.tag', () => {
+  const { rows } = parseEnvelope(txEnvelope(transaction()));
+  const root = rows[0];
+  expect(root.project).toBe('titanium'); // diag.project from contexts.trace.data
+  expect(root.run_id).toBe('run-7');
+  expect(root.tag).toBe('H2');
+  expect(root.logger).toBe('auto.http.otel.http'); // sentry.origin
+  expect(root.service).toBe('sentry.javascript.node'); // envelope sdk.name
+  // child has no diag.* — project/run_id default empty, logger from origin
+  expect(rows[1].project).toBe('');
+  expect(rows[1].run_id).toBe('');
+  expect(rows[1].logger).toBe('manual');
+});
+
+test('span data is persisted verbatim', () => {
+  const { rows } = parseEnvelope(txEnvelope(transaction()));
+  // child span data round-trips deep-equal to the source span object
+  const src = transaction().spans[1];
+  expect(JSON.parse(rows[2].data)).toEqual(src);
+});
+
+test('davstack-logs.db routing is honored for spans and stripped from persisted data', () => {
+  const tx = transaction();
+  // inject the routing hint into the root trace data (where the http.server
+  // root attributes live on the real wire)
+  (tx.contexts.trace.data as Record<string, unknown>)['davstack-logs.db'] = 'trace-bug';
+  const { rows } = parseEnvelope(txEnvelope(tx));
+  const root = rows[0];
+  expect(root.routeDb).toBe('trace-bug');
+  const persisted = JSON.parse(root.data) as { data: Record<string, unknown> };
+  expect(persisted.data['davstack-logs.db']).toBeUndefined();
+  expect(persisted.data['diag.project']).toBe('titanium'); // siblings preserved
+  // and it must not leak into the flattened attrs either
+  const flat = JSON.parse(root.attrs as string) as Record<string, unknown>;
+  expect(flat['davstack-logs.db']).toBeUndefined();
+});
+
+test('a standalone type:"span" item is handled defensively as one span row', () => {
+  const span = {
+    span_id: 'aa11bb22cc33dd44',
+    trace_id: 'd'.repeat(32),
+    description: 'cache.get user:42',
+    op: 'cache.get',
+    status: 'ok',
+    origin: 'auto.cache',
+    start_timestamp: 100.0,
+    timestamp: 100.25, // 250ms
+    data: { 'cache.hit': true },
+  };
+  const raw = [
+    JSON.stringify({ sdk: { name: 'sentry.javascript.node', version: '10.16.0' } }),
+    JSON.stringify({ type: 'span' }),
+    JSON.stringify(span),
+  ].join('\n');
+  const { rows, skipped } = parseEnvelope(raw);
+  expect(skipped).toBe(0);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].kind).toBe('span');
+  expect(rows[0].msg).toBe('cache.get user:42');
+  expect(rows[0].duration_ms).toBeCloseTo(250, 6);
+});
+
+test('back-compat: a mixed envelope (log item + transaction item) yields both kinds', () => {
+  // One envelope carrying a log item AND a transaction item — the parser must
+  // emit a kind:'log' row AND kind:'span' rows from the same body.
+  const raw = [
+    JSON.stringify({ sdk: { name: 'sentry.javascript.node', version: '10.16.0' } }),
+    JSON.stringify({ type: 'log', item_count: 1, content_type: 'application/vnd.sentry.items.log+json' }),
+    JSON.stringify({ items: [log({ body: 'a log line' })] }),
+    JSON.stringify({ type: 'transaction' }),
+    JSON.stringify(transaction()),
+  ].join('\n');
+  const { rows, skipped } = parseEnvelope(raw);
+  expect(skipped).toBe(0);
+  const byKind = rows.reduce<Record<string, number>>((acc, r) => {
+    acc[r.kind] = (acc[r.kind] ?? 0) + 1;
+    return acc;
+  }, {});
+  expect(byKind).toEqual({ log: 1, span: 3 });
+  const logRow = rows.find((r) => r.kind === 'log')!;
+  expect(logRow.msg).toBe('a log line');
+  expect(logRow.duration_ms).toBeNull();
+});

--- a/packages/logs-server/__tests__/envelope.test.ts
+++ b/packages/logs-server/__tests__/envelope.test.ts
@@ -354,6 +354,106 @@ test('a standalone type:"span" item is handled defensively as one span row', () 
   expect(rows[0].duration_ms).toBeCloseTo(250, 6);
 });
 
+//* MARK: Span tolerance
+
+// The sink's prime directive: never throw, never emit a corrupt row. These
+// exercise the degenerate trace shapes the span path already guards but that
+// the faithful-fixture cases above never hit. Each asserts the ACTUAL guard
+// behavior in envelope.ts — not an aspirational one.
+
+test('duration_ms is null (never NaN) when the root window has no top-level timestamp', () => {
+  // A transaction MISSING `timestamp` (and one missing `start_timestamp`): the
+  // root span window is undeterminable. durationMs() must yield null so the
+  // INSERT can't be corrupted with NaN/undefined.
+  const noEnd = transaction();
+  delete (noEnd as Record<string, unknown>).timestamp;
+  const r1 = parseEnvelope(txEnvelope(noEnd)).rows[0];
+  expect(r1.duration_ms).toBeNull();
+  expect(Number.isNaN(r1.duration_ms as unknown as number)).toBe(false);
+
+  const noStart = transaction();
+  delete (noStart as Record<string, unknown>).start_timestamp;
+  const r2 = parseEnvelope(txEnvelope(noStart)).rows[0];
+  expect(r2.duration_ms).toBeNull();
+});
+
+test('duration_ms is null (never NaN) for a child span missing its timestamp', () => {
+  // Corrupt one child: drop its end `timestamp`. That child row's duration is
+  // null; the well-formed sibling is unaffected. No throw, no NaN.
+  const tx = transaction();
+  delete (tx.spans[0] as Record<string, unknown>).timestamp;
+  const { rows, skipped } = parseEnvelope(txEnvelope(tx));
+  expect(skipped).toBe(0);
+  expect(rows).toHaveLength(3); // still root + 2 children
+  expect(rows[1].duration_ms).toBeNull(); // the corrupted child
+  expect(rows[2].duration_ms).toBeCloseTo(11.539, 3); // healthy sibling intact
+});
+
+test('root-only transaction (empty spans[]) emits exactly the single root span row', () => {
+  const { rows, skipped } = parseEnvelope(txEnvelope(transaction({ spans: [] })));
+  expect(skipped).toBe(0);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].kind).toBe('span');
+  expect(rows[0].msg).toBe('GET /api/test'); // the root transaction name
+});
+
+test('root-only transaction (spans key absent entirely) emits exactly the single root span row', () => {
+  const noSpans = transaction();
+  delete (noSpans as Record<string, unknown>).spans;
+  const { rows, skipped } = parseEnvelope(txEnvelope(noSpans));
+  expect(skipped).toBe(0);
+  expect(rows).toHaveLength(1);
+  expect(rows[0].kind).toBe('span');
+  expect(rows[0].msg).toBe('GET /api/test');
+});
+
+test('a transaction missing contexts.trace is tolerated: no root row, no throw', () => {
+  // No `contexts.trace` ⇒ the root guard (`if (trace && typeof trace === 'object')`)
+  // skips the root, and with no `spans[]` the result is zero span rows. The
+  // documented best-effort behavior here is "emit nothing, never throw".
+  const noTrace = transaction({ spans: [] });
+  delete (noTrace as Record<string, unknown>).contexts;
+  let result: ReturnType<typeof parseEnvelope> | undefined;
+  expect(() => {
+    result = parseEnvelope(txEnvelope(noTrace));
+  }).not.toThrow();
+  expect(result!.rows).toHaveLength(0); // no contexts.trace, no spans → nothing
+  expect(result!.skipped).toBe(0); // a parseable-but-empty tx is not "skipped"
+});
+
+test('a transaction missing contexts.trace still emits its child spans (best-effort)', () => {
+  // Same missing-root case but WITH children: the root is skipped, yet the
+  // self-timed child spans are still emitted (best-effort, not all-or-nothing).
+  const noTrace = transaction();
+  delete (noTrace as Record<string, unknown>).contexts;
+  const { rows, skipped } = parseEnvelope(txEnvelope(noTrace));
+  expect(skipped).toBe(0);
+  expect(rows).toHaveLength(2); // the two children, no root
+  expect(rows.every((r) => r.kind === 'span')).toBe(true);
+  expect(rows.map((r) => r.msg)).toEqual(['db.query users', 'http.client fetch']);
+});
+
+test('a malformed transaction payload is skipped, never throws, and a sibling log still parses', () => {
+  // transaction item header followed by a non-object garbage payload (a bare
+  // JSON string), then a perfectly good log item in the same envelope. The
+  // transaction is counted in `skipped`; the log still parses.
+  const raw = [
+    JSON.stringify({ sdk: { name: 'sentry.javascript.node', version: '10.16.0' } }),
+    JSON.stringify({ type: 'transaction' }),
+    JSON.stringify('not-a-transaction-object'), // valid JSON, but not an object
+    JSON.stringify({ type: 'log', item_count: 1, content_type: 'application/vnd.sentry.items.log+json' }),
+    JSON.stringify({ items: [log({ body: 'the surviving log' })] }),
+  ].join('\n');
+  let result: ReturnType<typeof parseEnvelope> | undefined;
+  expect(() => {
+    result = parseEnvelope(raw);
+  }).not.toThrow();
+  expect(result!.skipped).toBe(1); // the garbage transaction payload
+  expect(result!.rows).toHaveLength(1);
+  expect(result!.rows[0].kind).toBe('log');
+  expect(result!.rows[0].msg).toBe('the surviving log');
+});
+
 test('back-compat: a mixed envelope (log item + transaction item) yields both kinds', () => {
   // One envelope carrying a log item AND a transaction item — the parser must
   // emit a kind:'log' row AND kind:'span' rows from the same body.

--- a/packages/logs-server/package.json
+++ b/packages/logs-server/package.json
@@ -3,7 +3,7 @@
   "version": "2.6.1",
   "license": "MIT",
   "type": "module",
-  "description": "Local Sentry-shaped log sink: ingest envelopes over HTTP, persist to per-repo SQLite. Read with sqlite3 against the logs table (flat attrs column).",
+  "description": "Local Sentry-shaped telemetry sink (logs + traces): ingest envelopes over HTTP, persist to per-repo SQLite. Read with sqlite3 against the logs table (kind discriminates log vs span; flat attrs column).",
   "scripts": {
     "build": "tsup",
     "prepublishOnly": "tsup",

--- a/packages/logs-server/src/db.ts
+++ b/packages/logs-server/src/db.ts
@@ -6,25 +6,28 @@
 import { Database } from 'bun:sqlite';
 
 export type LogRow = {
-  ts: number; // client timestamp (Sentry log `timestamp`, seconds float)
+  ts: number; // client timestamp (Sentry log `timestamp` / span `start_timestamp`, seconds float)
   recv_ts: number; // server receive time, ms epoch (clock-skew-safe vs client `ts`)
+  kind: 'log' | 'span'; // row discriminator: a log record or a trace span
   project: string; // diag.project attribute (cwd/repo key)
   service: string; // envelope sdk.name
   run_id: string; // diag.run_id attribute
   trace_id: string;
   span_id: string;
-  level: string;
-  severity_number: number; // OTel 1..24
-  logger: string; // sentry.origin
-  msg: string; // log `body`
-  data: string; // raw log item JSON, verbatim
-  attrs: string | null; // flat key→value JSON, OTel {value,type} wrapper stripped (NULL when attributes missing/empty)
+  level: string; // logs: OTel level; spans: '' (no level — query by kind/op/status)
+  severity_number: number; // OTel 1..24 (0 for spans)
+  logger: string; // logs: sentry.origin; spans: span origin (fallback sdk.name)
+  msg: string; // log `body`; span description||op (root: transaction name||op)
+  data: string; // raw log item / span / transaction JSON, verbatim
+  attrs: string | null; // flat key→value JSON (NULL when none). Spans add op/status/parent_span_id/description/duration_ms.
   tag: string | null; // diag.tag attribution (optional)
+  duration_ms: number | null; // span headline metric ((timestamp - start_timestamp)*1000); NULL for logs
 };
 
 const COLS: (keyof LogRow)[] = [
   'ts',
   'recv_ts',
+  'kind',
   'project',
   'service',
   'run_id',
@@ -37,6 +40,7 @@ const COLS: (keyof LogRow)[] = [
   'data',
   'attrs',
   'tag',
+  'duration_ms',
 ];
 
 // Migrate pre-2.2 schemas: add the `attrs` column if missing, backfill from
@@ -71,6 +75,33 @@ function migrateAttrsColumn(db: Database): void {
   }
 }
 
+// Migrate pre-2.7 schemas to the telemetry shape: add `kind` (log|span) and
+// `duration_ms` columns if missing. Existing rows are all logs, so `kind`
+// backfills to 'log' (the column default already does this on ALTER, but we
+// set it explicitly for clarity / parity with fresh CREATE). `duration_ms`
+// stays NULL on legacy rows (only spans carry it). Wrapped in BEGIN IMMEDIATE
+// so partial state can't leak; idempotent (guarded by the table_info check).
+function migrateKindColumns(db: Database): void {
+  const cols = db.query('PRAGMA table_info(logs)').all() as { name: string }[];
+  const hasKind = cols.some((c) => c.name === 'kind');
+  const hasDuration = cols.some((c) => c.name === 'duration_ms');
+  if (hasKind && hasDuration) return;
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    if (!hasKind) {
+      db.exec("ALTER TABLE logs ADD COLUMN kind TEXT DEFAULT 'log'");
+      db.exec("UPDATE logs SET kind = 'log' WHERE kind IS NULL");
+    }
+    if (!hasDuration) {
+      db.exec('ALTER TABLE logs ADD COLUMN duration_ms REAL');
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
 export function openDb(path: string): Database {
   const db = new Database(path);
   db.exec('PRAGMA journal_mode = WAL'); // concurrent hammer-ingest + query
@@ -79,6 +110,7 @@ export function openDb(path: string): Database {
       id              INTEGER PRIMARY KEY,
       ts              REAL,
       recv_ts         REAL,
+      kind            TEXT DEFAULT 'log',
       project         TEXT,
       service         TEXT,
       run_id          TEXT,
@@ -90,13 +122,15 @@ export function openDb(path: string): Database {
       msg             TEXT,
       data            TEXT,
       attrs           TEXT,
-      tag             TEXT
+      tag             TEXT,
+      duration_ms     REAL
     )`);
   db.exec(
     `CREATE INDEX IF NOT EXISTS idx_logs_corr
        ON logs (project, run_id, trace_id, level, ts)`,
   );
   migrateAttrsColumn(db);
+  migrateKindColumns(db);
   return db;
 }
 

--- a/packages/logs-server/src/envelope.ts
+++ b/packages/logs-server/src/envelope.ts
@@ -1,10 +1,29 @@
-// The Sentry log-envelope parser. Deliberately Sentry-coupled (notes 03), and
-// deliberately TOLERANT: it never throws to the caller and never drops a whole
-// batch for one bad line — a malformed/unknown line is skipped, a non-`log`
-// item is ignored, the full log record is always kept verbatim in `data`.
+// The Sentry telemetry-envelope parser. Deliberately Sentry-coupled (notes 03),
+// and deliberately TOLERANT: it never throws to the caller and never drops a
+// whole batch for one bad line — a malformed/unknown line is skipped, an
+// unsupported item type is ignored, the full record is always kept verbatim in
+// `data`.
+//
 // Wire format (notes 03): newline-delimited JSON — an envelope header line,
-// then (item header, item payload) line pairs; a `log` payload is
-// `{ items: [ <log>, ... ] }`.
+// then (item header, item payload) line pairs. Two item types are persisted:
+//
+//   type:"log" payload = `{ items: [ <log>, ... ] }` → one `kind:'log'` row per
+//     item (severity, body, OTel {value,type} attributes).
+//
+//   type:"transaction" payload = a transaction *event* (Sentry tracing). Shape
+//     captured live from @sentry/node 10.16.0 (real wire, not a guess):
+//       { transaction, start_timestamp, timestamp, type:"transaction",
+//         contexts: { trace: { trace_id, span_id, parent_span_id?, op, status,
+//                              origin, data } },
+//         spans: [ { span_id, parent_span_id, trace_id, op, description, status,
+//                    origin, start_timestamp, timestamp, data } ... ] }
+//     → ROOT row from `contexts.trace` (timing from top-level start/timestamp)
+//       PLUS one row per `spans[]` entry. Each is a `kind:'span'` row.
+//     `type:"span"` standalone items (Sentry's newer span-streaming protocol)
+//     are handled defensively as a single span.
+//
+// Span `data` is a PLAIN object (NOT the log {value,type} wrapper) — it gets its
+// own flattener; the log unwrap is never applied to it.
 
 import type { LogRow } from './db.js';
 
@@ -71,6 +90,7 @@ function toRow(rec: Record<string, unknown>, sdkName: string, envTraceId: string
 
   return {
     ts: typeof rec.timestamp === 'number' ? rec.timestamp : Number(rec.timestamp) || 0,
+    kind: 'log',
     project: strOr(attrVal(attrs, 'diag.project'), ''),
     service: sdkName,
     run_id: strOr(attrVal(attrs, 'diag.run_id'), ''),
@@ -83,8 +103,153 @@ function toRow(rec: Record<string, unknown>, sdkName: string, envTraceId: string
     data: JSON.stringify(recForPersist), // verbatim — minus the routing key
     attrs: flattenAttrs(attrsForFlatten),
     tag: diagTag === undefined || diagTag === null ? null : String(diagTag),
+    duration_ms: null,
     routeDb,
   };
+}
+
+//* MARK: Spans
+
+// A span row carries no severity and no OTel-wrapped attributes — its `data` is
+// the verbatim span/transaction-trace object. We surface the span's headline
+// fields (op, status, parent, description, duration_ms) into the flat `attrs`
+// JSON so they're `json_extract`-queryable alongside the span's own plain data.
+
+// Flatten a span's plain `data` object (NO {value,type} unwrap — that's
+// log-only) into a flat map, merged with the span-specific headline fields.
+// Returns null only when there is genuinely nothing to record.
+function flattenSpanAttrs(
+  spanData: Record<string, unknown> | undefined,
+  headline: Record<string, unknown>,
+): string | null {
+  const flat: Record<string, unknown> = {};
+  if (spanData) for (const k of Object.keys(spanData)) flat[k] = spanData[k];
+  for (const k of Object.keys(headline)) {
+    if (headline[k] !== undefined && headline[k] !== null) flat[k] = headline[k];
+  }
+  if (Object.keys(flat).length === 0) return null;
+  return JSON.stringify(flat);
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+function durationMs(start: unknown, end: unknown): number | null {
+  const s = num(start);
+  const e = num(end);
+  if (s === undefined || e === undefined) return null;
+  return (e - s) * 1000;
+}
+
+// Build one span row. `spanObj` is the verbatim span (or trace context) object;
+// `msg` is its display string; `start`/`end` give the timing. The
+// `davstack-logs.db` routing hint and diag.* attribution are pulled from the
+// span's plain `data` (analogous to logs), stripped from the persisted copy.
+function spanRow(opts: {
+  spanObj: Record<string, unknown>;
+  msg: string;
+  start: unknown;
+  end: unknown;
+  sdkName: string;
+  envTraceId: string;
+}): ParsedLog {
+  const { spanObj, msg, start, end, sdkName, envTraceId } = opts;
+  const rawData = (spanObj.data as Record<string, unknown> | undefined) ?? undefined;
+
+  // Pull routing + attribution from the span's plain data, then strip the
+  // routing key from the persisted copy (the DB file is the session indicator).
+  let routeDb: string | undefined;
+  let dataForPersist: Record<string, unknown> | undefined = rawData;
+  let objForPersist: Record<string, unknown> = spanObj;
+  if (rawData && ROUTE_DB_ATTR in rawData) {
+    const v = rawData[ROUTE_DB_ATTR];
+    if (typeof v === 'string' && v.length > 0) routeDb = v;
+    const { [ROUTE_DB_ATTR]: _drop, ...rest } = rawData;
+    void _drop;
+    dataForPersist = rest;
+    objForPersist = { ...spanObj, data: rest };
+  }
+
+  const dur = durationMs(start, end);
+  const diagTag = dataForPersist?.['diag.tag'];
+  const op = dataForPersist?.['sentry.op'] ?? spanObj.op;
+  const headline: Record<string, unknown> = {
+    op: op ?? undefined,
+    status: spanObj.status,
+    parent_span_id: spanObj.parent_span_id,
+    description: spanObj.description,
+    duration_ms: dur ?? undefined,
+  };
+
+  return {
+    ts: num(start) ?? 0,
+    kind: 'span',
+    project: strOr(dataForPersist?.['diag.project'], ''),
+    service: sdkName,
+    run_id: strOr(dataForPersist?.['diag.run_id'], ''),
+    trace_id: strOr(spanObj.trace_id ?? envTraceId, ''),
+    span_id: strOr(spanObj.span_id, ''),
+    level: '', // spans carry no level; discriminate via kind='span'
+    severity_number: 0,
+    logger: strOr(dataForPersist?.['sentry.origin'] ?? spanObj.origin ?? sdkName, ''),
+    msg,
+    data: JSON.stringify(objForPersist), // verbatim — minus the routing key
+    attrs: flattenSpanAttrs(dataForPersist, headline),
+    tag: diagTag === undefined || diagTag === null ? null : String(diagTag),
+    duration_ms: dur,
+    routeDb,
+  };
+}
+
+// Expand a transaction event into its span rows: the ROOT (from
+// `contexts.trace`, timed by the event's top-level start/timestamp) plus one
+// row per `spans[]` child (each self-timed). Emitted in that order.
+function transactionRows(
+  tx: Record<string, unknown>,
+  sdkName: string,
+  envTraceId: string,
+): ParsedLog[] {
+  const out: ParsedLog[] = [];
+  const trace = (tx.contexts as Record<string, unknown> | undefined)?.trace as
+    | Record<string, unknown>
+    | undefined;
+
+  if (trace && typeof trace === 'object') {
+    const op = (trace.data as Record<string, unknown> | undefined)?.['sentry.op'] ?? trace.op;
+    const rootMsg = strOr(tx.transaction ?? op, '');
+    out.push(
+      spanRow({
+        spanObj: trace,
+        msg: rootMsg,
+        start: tx.start_timestamp,
+        end: tx.timestamp,
+        sdkName,
+        envTraceId,
+      }),
+    );
+  }
+
+  const spans = tx.spans;
+  if (Array.isArray(spans)) {
+    for (const s of spans) {
+      if (!s || typeof s !== 'object') continue;
+      const span = s as Record<string, unknown>;
+      const op = (span.data as Record<string, unknown> | undefined)?.['sentry.op'] ?? span.op;
+      const msg = strOr(span.description ?? op, '');
+      out.push(
+        spanRow({
+          spanObj: span,
+          msg,
+          start: span.start_timestamp,
+          end: span.timestamp,
+          sdkName,
+          envTraceId,
+        }),
+      );
+    }
+  }
+  return out;
 }
 
 function tryParse(line: string): unknown | undefined {
@@ -119,19 +284,56 @@ export function parseEnvelope(raw: string): { rows: ParsedLog[]; skipped: number
     }
     const payload = tryParse(lines[i + 1] ?? '');
     i += 2; // a well-formed item consumes header + payload
-    if (itemHeader.type !== 'log') continue; // ignore non-log items
-    const items = (payload as { items?: unknown[] } | undefined)?.items;
-    if (!Array.isArray(items)) {
-      skipped += 1; // log item header but unusable payload
+
+    if (itemHeader.type === 'log') {
+      const items = (payload as { items?: unknown[] } | undefined)?.items;
+      if (!Array.isArray(items)) {
+        skipped += 1; // log item header but unusable payload
+        continue;
+      }
+      for (const entry of items) {
+        if (entry && typeof entry === 'object') {
+          rows.push(toRow(entry as Record<string, unknown>, sdkName, envTraceId));
+        } else {
+          skipped += 1;
+        }
+      }
       continue;
     }
-    for (const entry of items) {
-      if (entry && typeof entry === 'object') {
-        rows.push(toRow(entry as Record<string, unknown>, sdkName, envTraceId));
+
+    if (itemHeader.type === 'transaction') {
+      // A transaction event expands to its root + child span rows.
+      if (payload && typeof payload === 'object') {
+        rows.push(...transactionRows(payload as Record<string, unknown>, sdkName, envTraceId));
+      } else {
+        skipped += 1; // transaction header but unusable payload
+      }
+      continue;
+    }
+
+    if (itemHeader.type === 'span') {
+      // Standalone span item (Sentry's newer span-streaming protocol) — a
+      // single plain span object, no transaction envelope around it.
+      if (payload && typeof payload === 'object') {
+        const span = payload as Record<string, unknown>;
+        const op = (span.data as Record<string, unknown> | undefined)?.['sentry.op'] ?? span.op;
+        rows.push(
+          spanRow({
+            spanObj: span,
+            msg: strOr(span.description ?? op, ''),
+            start: span.start_timestamp,
+            end: span.timestamp,
+            sdkName,
+            envTraceId,
+          }),
+        );
       } else {
         skipped += 1;
       }
+      continue;
     }
+
+    // Any other item type (event, profile, session, ...) is ignored.
   }
 
   return { rows, skipped };


### PR DESCRIPTION
## What & why

`@davstack/logs-server` is a local Sentry-shaped sink (HTTP envelopes → SQLite). Until now it only ingested `type:"log"` items and **dropped** `type:"transaction"`/`type:"span"` items. This PR makes it ingest **traces (spans)** as first-class, queryable rows in the same `logs` table — reframing the package from a log sink to a **telemetry sink (logs + traces)**. Package name unchanged.

## The `kind` column + migration

- New `LogRow.kind: 'log' | 'span'` discriminator and `duration_ms: number | null` (spans' headline metric — a real column so spans sort by latency in plain SQL).
- `CREATE TABLE` adds `kind TEXT DEFAULT 'log'` and `duration_ms REAL`.
- New **idempotent** `migrateKindColumns` (mirrors the existing `migrateAttrsColumn` guarded `PRAGMA table_info` + `BEGIN IMMEDIATE` pattern): adds the two columns to pre-existing DBs, defaulting every existing row to `kind:'log'` with `duration_ms` NULL. Safe to re-run.

## Span mapping (`envelope.ts`)

Log path is **untouched** — existing rows now just carry `kind:'log'`, `duration_ms:null`. Added:

- **`type:"transaction"`** → one row per span: the **root** (from `contexts.trace`, timed by the event's top-level `start_timestamp`/`timestamp`) **plus** one row per `spans[]` child (self-timed). Root msg = transaction name || op; child msg = `description` || op.
- **`type:"span"`** standalone items handled defensively as a single span.
- Per span row: `kind:'span'`, `ts = start_timestamp`, `duration_ms = (timestamp - start_timestamp) * 1000`, `level:''` (spans carry no level — discriminate via `kind`/`op`/`status`), `logger` from span `origin` (fallback envelope `sdk.name`), `data` = verbatim span/trace object, `tag` from `diag.tag`.
- Span-specific fields (`op`, `status`, `parent_span_id`, `description`, `duration_ms`) are flattened into the `json_extract`-queryable `attrs` JSON.
- **Span `data` is a PLAIN object** (not the OTel `{value,type}` wrapper logs use) — a dedicated `flattenSpanAttrs` is used; the log `attrVal`/`flattenAttrs` unwrap is never applied to span data.
- `davstack-logs.db` routing is honored for spans (stripped from persisted data, surfaced as `routeDb`); `diag.project`/`diag.run_id` attribution pulled from span data, else envelope header.

`ingest.ts`/`server.ts` needed **no change** — they thread `LogRow` generically, so `kind`/`duration_ms` flow through `insertLogs` and dispatch routing unchanged (verified by the bun-only ingest/acceptance suites).

## Back-compat guarantees

- Every existing log path still produces `kind:'log'` rows; all pre-existing tests stay green.
- Idempotent migration backfills legacy DBs to `kind:'log'`.
- A mixed envelope (log item + transaction item) yields **both** a `kind:'log'` row and `kind:'span'` rows (tested).

## How to query spans

```sql
SELECT msg, duration_ms,
       json_extract(attrs, '$.op')     AS op,
       json_extract(attrs, '$.status') AS status
FROM logs
WHERE kind = 'span'
ORDER BY duration_ms DESC;
```

Logs and spans share `trace_id`, so a single `WHERE trace_id = ?` slices the full request timeline across both.

## Faithful fixture

The transaction test fixture was captured **live from `@sentry/node` 10.16.0** (real wire, not a guess), cited in a test comment. Notable detail vs the original brief: the root span's timing and `davstack-logs.db`/`diag.*` routing live in `contexts.trace.data` + the event's **top-level** `start_timestamp`/`timestamp` — the trace context itself carries no `start_timestamp`/`timestamp`. The implementation handles this faithfully.

## Test evidence

vitest project (`logs-server`) — all green:

```
✓ __tests__/db-route.test.ts  (20 tests)
✓ __tests__/envelope.test.ts  (19 tests)   <- +7 new span tests
✓ __tests__/check.test.ts     (17 tests)
Test Files  3 passed (3)
Tests       56 passed (56)
```

bun-only db/ingest/acceptance (run with corrected import depth) — all green:

```
12 pass  0 fail  (db migration + kind/duration_ms, ingest, real-HTTP acceptance)
```

`pnpm build` (tsup) — ESM + DTS build success. New code adds no type errors (pre-existing `tsc` `bun:sqlite`/`Bun` global gaps are unrelated and handled via tsup `external`).

> Note: the `__tests__/bun-only/*` files import `../src/*.js` which doesn't resolve under stock `bun test` from this layout on **either** this branch or `origin/main` (pre-existing). They were verified by running copies at the correct depth. The canonical CI command is the vitest project, which excludes `bun-only`.
